### PR TITLE
feat: add user and add validator tasks

### DIFF
--- a/playbooks/add_validator.yml
+++ b/playbooks/add_validator.yml
@@ -1,0 +1,10 @@
+# Copyright (C) 2022, Léo Schoukroun
+# See the file LICENSE for licensing terms.
+---
+- name: Add validator playbook
+  hosts: avalanche_nodes
+  tasks:
+    - name: Add validator task
+      include_role:
+        name: ash.avalanche.node
+        tasks_from: add-validator.yml

--- a/playbooks/create_admin_user.yml
+++ b/playbooks/create_admin_user.yml
@@ -1,0 +1,10 @@
+# Copyright (C) 2022, Léo Schoukroun
+# See the file LICENSE for licensing terms.
+---
+- name: Create admin user playbook
+  hosts: avalanche_nodes
+  tasks:
+    - name: Create admin user task
+      include_role:
+        name: ash.avalanche.node
+        tasks_from: admin-user.yml

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -86,3 +86,8 @@ avalanche_node_password: password
 avalanche_prefunded_username: ewoq
 avalanche_prefunded_password: I_l1ve_@_Endor
 avalanche_prefunded_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
+
+# Validation properties
+avalanchego_validation_start_time: "{{ ansible_date_time.epoch | int + 60 }}" # in 1 minute
+avalanchego_validation_end_time: "{{ ansible_date_time.epoch | int + 60 + 604800 }}" # in 1 week
+avalanchego_validation_stake_amount: 1000000000 # 1000000000 nAVAX = 1 AVAX

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -77,7 +77,12 @@ avalanchego_chains_configs:
   C:
     state-sync-enabled: true
 
-# Pre-funded account (only on local network)
+# Node keystore
+## "admin user" (used by admin-user and validate tasks)
+avalanche_node_username: admin
+avalanche_node_password: password
+
+## Pre-funded account (only on local network)
 avalanche_prefunded_username: ewoq
 avalanche_prefunded_password: I_l1ve_@_Endor
 avalanche_prefunded_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -14,22 +14,6 @@
   register: list_addresses_res
   failed_when: list_addresses_res.json.error is defined or list_addresses_res.json.result.addresses | length < 1
 
-- name: Export P chain key
-  uri:
-    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
-    method: POST
-    body_format: json
-    body:
-      jsonrpc: "2.0"
-      method: platform.exportKey
-      params:
-        username: "{{ avalanche_node_username }}"
-        password: "{{ avalanche_node_password }}"
-        address: "{{ list_addresses_res.json.result.addresses[0] }}"
-      id: 1
-  register: export_key_res
-  failed_when: export_key_res.json.error is defined
-
 - name: Get current P chain height
   uri:
     url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -1,0 +1,92 @@
+---
+- name: Get P chain address
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.listAddresses
+      params:
+        username: "{{ avalanche_node_username }}"
+        password: "{{ avalanche_node_password }}"
+      id: 1
+  register: list_addresses_res
+  failed_when: list_addresses_res.json.error is defined or list_addresses_res.json.result.addresses | length < 1
+
+- name: Export P chain key
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.exportKey
+      params:
+        username: "{{ avalanche_node_username }}"
+        password: "{{ avalanche_node_password }}"
+        address: "{{ list_addresses_res.json.result.addresses[0] }}"
+      id: 1
+  register: export_key_res
+  failed_when: export_key_res.json.error is defined
+
+- name: Get current P chain height
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.getHeight
+      id: 1
+  register: get_height_res
+  failed_when: get_height_res.json.error is defined
+
+- name: Get current P chain validators
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.getValidatorsAt
+      params:
+        height: "{{ get_height_res.json.result.height }}"
+        subnetID: "11111111111111111111111111111111LpoYY"
+      id: 1
+  register: get_validators_res
+  failed_when: get_validators_res.json.error is defined
+
+- name: Get NodeID
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/info"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: info.getNodeID
+      id: 1
+  register: get_node_id_res
+  failed_when: get_node_id_res.json.error is defined
+
+- name: Add validator if not already validating
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.addValidator
+      params:
+        nodeID: "{{ get_node_id_res.json.result.nodeID }}"
+        startTime: "{{ ansible_date_time.epoch | int + 60 }}"
+        endTime: "{{ ansible_date_time.epoch | int + 60 + 604800 }}"
+        stakeAmount: 1000000000
+        rewardAddress: "{{ list_addresses_res.json.result.addresses[0] }}"
+        delegationFeeRate: 10
+        username: "{{ avalanche_node_username }}"
+        password: "{{ avalanche_node_password }}"
+      id: 1
+  when: get_node_id_res.json.result.nodeID not in get_validators_res.json.result.validators
+  register: add_validator_res
+  failed_when: add_validator_res.json.error is defined

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -41,23 +41,21 @@
   failed_when: get_current_validators_res.json.error is defined
 
 - name: Add validator if not already validating
-  uri:
-    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
-    method: POST
-    body_format: json
-    body:
-      jsonrpc: "2.0"
-      method: platform.addValidator
-      params:
-        nodeID: "{{ get_node_id_res.json.result.nodeID }}"
-        startTime: "{{ avalanchego_validation_start_time }}"
-        endTime: "{{ avalanchego_validation_end_time }}"
-        stakeAmount: "{{ avalanchego_validation_stake_amount }}"
-        rewardAddress: "{{ list_addresses_res.json.result.addresses[0] }}"
-        delegationFeeRate: 10
-        username: "{{ avalanche_node_username }}"
-        password: "{{ avalanche_node_password }}"
-      id: 1
+  ash.avalanche.tx:
+    http_host: "{{ avalanchego_http_host }}"
+    http_port: "{{ avalanchego_http_port }}"
+    blockchain: P
+    method: platform.addValidator
+    username: "{{ avalanche_node_username }}"
+    password: "{{ avalanche_node_password }}"
+    params:
+      nodeID: "{{ get_node_id_res.json.result.nodeID }}"
+      startTime: "{{ avalanchego_validation_start_time }}"
+      endTime: "{{ avalanchego_validation_end_time }}"
+      stakeAmount: "{{ avalanchego_validation_stake_amount }}"
+      rewardAddress: "{{ list_addresses_res.json.result.addresses[0] }}"
+      delegationFeeRate: 10
+      username: "{{ avalanche_node_username }}"
+      password: "{{ avalanche_node_password }}"
+    wait_validation: yes
   when: get_current_validators_res.json.result.validators | length  < 1
-  register: add_validator_res
-  failed_when: add_validator_res.json.error is defined

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -14,33 +14,6 @@
   register: list_addresses_res
   failed_when: list_addresses_res.json.error is defined or list_addresses_res.json.result.addresses | length < 1
 
-- name: Get current P chain height
-  uri:
-    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
-    method: POST
-    body_format: json
-    body:
-      jsonrpc: "2.0"
-      method: platform.getHeight
-      id: 1
-  register: get_height_res
-  failed_when: get_height_res.json.error is defined
-
-- name: Get current P chain validators
-  uri:
-    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
-    method: POST
-    body_format: json
-    body:
-      jsonrpc: "2.0"
-      method: platform.getValidatorsAt
-      params:
-        height: "{{ get_height_res.json.result.height }}"
-        subnetID: "11111111111111111111111111111111LpoYY"
-      id: 1
-  register: get_validators_res
-  failed_when: get_validators_res.json.error is defined
-
 - name: Get NodeID
   uri:
     url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/info"
@@ -52,6 +25,20 @@
       id: 1
   register: get_node_id_res
   failed_when: get_node_id_res.json.error is defined
+
+- name: Check if node is already a P chain validator
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.getCurrentValidators
+      params:
+        nodeIDs: ["{{ get_node_id_res.json.result.nodeID }}"]
+      id: 1
+  register: get_current_validators_res
+  failed_when: get_current_validators_res.json.error is defined
 
 - name: Add validator if not already validating
   uri:
@@ -71,6 +58,6 @@
         username: "{{ avalanche_node_username }}"
         password: "{{ avalanche_node_password }}"
       id: 1
-  when: get_node_id_res.json.result.nodeID not in get_validators_res.json.result.validators
+  when: get_current_validators_res.json.result.validators | length  < 1
   register: add_validator_res
   failed_when: add_validator_res.json.error is defined

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -63,9 +63,9 @@
       method: platform.addValidator
       params:
         nodeID: "{{ get_node_id_res.json.result.nodeID }}"
-        startTime: "{{ ansible_date_time.epoch | int + 60 }}"
-        endTime: "{{ ansible_date_time.epoch | int + 60 + 604800 }}"
-        stakeAmount: 1000000000
+        startTime: "{{ avalanchego_validation_start_time }}"
+        endTime: "{{ avalanchego_validation_end_time }}"
+        stakeAmount: "{{ avalanchego_validation_stake_amount }}"
         rewardAddress: "{{ list_addresses_res.json.result.addresses[0] }}"
         delegationFeeRate: 10
         username: "{{ avalanche_node_username }}"

--- a/roles/node/tasks/admin-user.yml
+++ b/roles/node/tasks/admin-user.yml
@@ -1,0 +1,59 @@
+---
+- name: Check if node user account already exists
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/keystore"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: keystore.listUsers
+      id: 1
+  register: list_users_res
+  failed_when: list_users_res.json.error is defined
+
+- name: Create node user account
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/keystore"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: keystore.createUser
+      params:
+        username: "{{ avalanche_node_username }}"
+        password: "{{ avalanche_node_password }}"
+      id: 1
+  when: avalanche_node_username not in list_users_res.json.result.users
+  register: users_create_res
+  failed_when: users_create_res.json.error is defined
+
+- name: Check if P chain address already exists
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.listAddresses
+      params:
+        username: "{{ avalanche_node_username }}"
+        password: "{{ avalanche_node_password }}"
+      id: 1
+  register: list_addresses_res
+  failed_when: list_addresses_res.json.error is defined
+
+- name: Create P chain address for node user account
+  uri:
+    url: "http://{{ avalanchego_http_host }}:{{ avalanchego_http_port }}/ext/bc/P"
+    method: POST
+    body_format: json
+    body:
+      jsonrpc: "2.0"
+      method: platform.createAddress
+      params:
+        username: "{{ avalanche_node_username }}"
+        password: "{{ avalanche_node_password }}"
+      id: 1
+  when: list_addresses_res.json.result.addresses | length < 1
+  register: create_address_res
+  failed_when: create_address_res.json.error is defined


### PR DESCRIPTION
**Note**: The funding of the created P-chain address created for the `admin` user must be done manually between calling `playbooks/create_admin_user.yml` and `playbooks/add_validator.yml`.

I'm not sure if we should invest time in automating this now.