### PR TITLE
feat: add convert ansible filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+
+*.pyc

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The repository [ansible-avalanche-getting-started](https://github.com/AshAvalanc
 
 - [ash.avalanche.tx](./plugins/modules): submit a transaction to an Avalanche network
 
+### Filters
+
+- [ash.avalanche.convert](./plugins/filter): convert an amount between AVAX units
+
 ### Roles
 
 - [ash.avalanche.node](./roles/node): install, configure and upgrade Avalanche nodes

--- a/plugins/filter/README.md
+++ b/plugins/filter/README.md
@@ -1,0 +1,34 @@
+# ash.avalanche filters
+
+The collection provides the following filters:
+
+- `ash.avalanche.convert`: convert an amount between AVAX units
+
+## ash.avalanche.convert
+
+### Usage
+
+This filter is useful to submit transactions without errors in the number of zeros:
+
+```yaml
+ash.avalanche.tx:
+  http_host: "{{ avalanchego_http_host }}"
+  blockchain: X
+  method: avm.send
+  username: "{{ avax_transfer_from_username }}"
+  password: "{{ avax_transfer_from_password }}"
+  params:
+    to: "{{ avax_transfer_to_address_bech32 }}"
+    assetID: AVAX
+    amount: "{{ 25 | ash.avalanche.convert('AVAX', 'nAVAX') | int }}"
+```
+
+### Supported units
+
+| Unit              | Amount in wei                  |
+| ----------------- | ------------------------------ |
+| `wei`             | `1`                            |
+| `gwei` or `navax` | `1e9` (`1000000000`)           |
+| `avax` or `eth`   | `1e18` (`1000000000000000000`) |
+
+**Note:** The filter is not case sensitive: `ash.avalanche.convert('AVAX', 'nAVAX')` is the same as `ash.avalanche.convert('avax', 'navax')`

--- a/plugins/filter/convert.py
+++ b/plugins/filter/convert.py
@@ -1,0 +1,29 @@
+#!/usr/bin/python
+# Copyright 2022 TOSIT.IO
+# SPDX-License-Identifier: Apache-2.0
+
+from ansible.errors import AnsibleError
+
+
+class FilterModule(object):
+    def filters(self):
+        return {'convert': self.convert}
+
+    def convert(self, amount, from_unit, to_unit):
+        units = {
+            'wei': 1,
+            'gwei': 1e9,
+            'navax': 1e9,
+            'avax': 1e18,
+            'eth': 1e18,
+        }
+
+        from_unit_lower = from_unit.lower()
+        to_unit_lower = to_unit.lower()
+
+        if from_unit_lower not in units.keys() or to_unit_lower not in units.keys():
+            raise AnsibleError(
+                f'Unknown unit. Available units: {", ".join(units.keys())}'
+            )
+
+        return amount * units[from_unit_lower] / units[to_unit_lower]

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -83,4 +83,4 @@ avalanche_prefunded_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgch
 # Validation properties
 avalanchego_validation_start_time: "{{ ansible_date_time.epoch | int + 60 }}" # in 1 minute
 avalanchego_validation_end_time: "{{ ansible_date_time.epoch | int + 60 + 604800 }}" # in 1 week
-avalanchego_validation_stake_amount: 1000000000 # 1000000000 nAVAX = 1 AVAX
+avalanchego_validation_stake_amount: "{{ 1 | ash.avalanche.convert('AVAX', 'nAVAX') | int }}"


### PR DESCRIPTION
This PR adds a new filter to the collection to easily convert between AVAX units. E.g.:
```yml
amount: "{{ 25 | ash.avalanche.convert('AVAX', 'nAVAX') | int }}"
```