### PR TITLE
fix: remove duplicate plugins dir creation

### DIFF
--- a/roles/node/tasks/install-avalanchego.yml
+++ b/roles/node/tasks/install-avalanchego.yml
@@ -50,15 +50,6 @@
     group: "{{ avalanchego_user }}"
   notify: Restart avalanchego
 
-- name: Create the symlink to current evm binary in plugins dir
-  file:
-    src: "{{ avalanchego_install_dir }}/avalanchego-v{{ avalanchego_version }}/plugins/evm"
-    dest: "{{ avalanchego_plugins_dir }}/evm"
-    state: link
-    owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
-  notify: Restart avalanchego
-
 - name: Template avalanchego.service file
   template:
     src: avalanchego.service.j2


### PR DESCRIPTION
### Linked issues

<!-- List of issues this PR fixes. E.g.

- Fixes #12
- Fixes #14

-->

Fix #20

### Dependencies

<!-- List of PR that need to be merged before this PR. E.g.

- https://github.com/AshAvalanche/ash-infra/pull/26
- https://github.com/AshAvalanche/ansible-avalanche-collection/pull/32

If empty, please remove the section title -->

### Changes

<!-- List of changes brought by the PR. Proposed format: "- _(scope)_ Description". E.g.

- _(lib)_ Add 4 networks with [Ankr](https://www.ankr.com/) and [Blast](https://blastapi.io/) endpoints to `conf/default.yml` (e.g. `fuji-ankr`). Both services provide decentralized public RPC endpoints. This allows going around Ava Labs' public RPC rate limiting which is very low.
- _(ci)_ Add a GitHub Actions workflow to run tests on PRs

-->

### Additional comments

<!-- You can for example ask for feedback here or link to new issues deriving from the PR.
If empty, please remove the section title -->
