### PR TITLE
chore: uniformize license headers

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, Gauthier Leonard
+Copyright (c) 2022-2023, E36 Knots
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 
 ### REQUIRED
 # The namespace of the collection. This can be a company/brand/organization or product namespace under which all
@@ -19,11 +19,12 @@ readme: README.md
 # A list of the collection's content authors. Can be just the name or in the format 'Full Name <email> (url)
 # @nicks:irc/im.site#channel'
 authors:
-  - Gauthier Leonard <gauthier_leonard@msn.com>
+  - Gauthier Leonard <gauthier@e36knots.com>
+  - Léo Schoukroun <leo@e36knots.com>
 
 ### OPTIONAL but strongly recommended
 # A short summary description of the collection
-description: Ansible roles to manage Avalanche nodes, subnets and blockchains
+description: Ansible roles to manage Avalanche nodes, Subnets and blockchains
 
 # The path to the license file for the collection. This path is relative to the root of the collection. This key is
 # mutually exclusive with 'license'
@@ -45,7 +46,7 @@ dependencies: {}
 repository: https://github.com/AshAvalanche/ansible-avalanche-collection
 
 # The URL to any online docs
-documentation: https://github.com/AshAvalanche/ansible-avalanche-getting-started
+documentation: https://docs.ash.center/docs/tools/ansible-avalanche-collection/overview
 
 # The URL to the homepage of the collection/project
 homepage: http://example.com

--- a/playbooks/add_validator.yml
+++ b/playbooks/add_validator.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Léo Schoukroun
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Add validator playbook
   hosts: avalanche_nodes

--- a/playbooks/bootstrap_local_network.yml
+++ b/playbooks/bootstrap_local_network.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Provision bootstrap node
   hosts: bootstrap_node

--- a/playbooks/create_admin_user.yml
+++ b/playbooks/create_admin_user.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Léo Schoukroun
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Create admin user playbook
   hosts: avalanche_nodes

--- a/playbooks/create_local_blockchains.yml
+++ b/playbooks/create_local_blockchains.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Create the blockchains
   hosts: subnet_control_node

--- a/playbooks/create_local_subnet.yml
+++ b/playbooks/create_local_subnet.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Create the subnet
   hosts: subnet_control_node

--- a/playbooks/provision_nodes.yml
+++ b/playbooks/provision_nodes.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Provision nodes
   hosts: avalanche_nodes

--- a/playbooks/transfer_avax.yml
+++ b/playbooks/transfer_avax.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Transfer AVAX from the X-Chain to the C-Chain
   hosts: api_node

--- a/plugins/filter/convert.py
+++ b/plugins/filter/convert.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-# Copyright 2022 TOSIT.IO
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 
 from ansible.errors import AnsibleError
 

--- a/plugins/filter/crypto.py
+++ b/plugins/filter/crypto.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
-# Copyright 2022 TOSIT.IO
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 
 from ansible.errors import AnsibleError
 

--- a/plugins/modules/eth_call.py
+++ b/plugins/modules/eth_call.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+
 from __future__ import absolute_import, division, print_function
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native

--- a/plugins/modules/tx.py
+++ b/plugins/modules/tx.py
@@ -1,7 +1,8 @@
 #!/usr/bin/python
 
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+
 from __future__ import absolute_import, division, print_function
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.text.converters import jsonify

--- a/roles/blockchain/defaults/main.yml
+++ b/roles/blockchain/defaults/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 # Network
 avalanchego_http_host: 127.0.0.1

--- a/roles/blockchain/tasks/main.yml
+++ b/roles/blockchain/tasks/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Include AvalancheGo VMs list
   include_vars: ../../node/vars/main.yml

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 # Avalanchego version
 avalanchego_version: 1.9.9

--- a/roles/node/handlers/main.yml
+++ b/roles/node/handlers/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Restart avalanchego
   service:

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Get P chain address
   uri:

--- a/roles/node/tasks/admin-user.yml
+++ b/roles/node/tasks/admin-user.yml
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Check if node user account already exists
   uri:

--- a/roles/node/tasks/ash-node.yml
+++ b/roles/node/tasks/ash-node.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Get NodeID
   uri:

--- a/roles/node/tasks/bootstrap-db.yml
+++ b/roles/node/tasks/bootstrap-db.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Unpack bootstrap database
   unarchive:

--- a/roles/node/tasks/config-chains.yml
+++ b/roles/node/tasks/config-chains.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Create chains conf dirs
   file:

--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Set bootstrap_ip
   set_fact:

--- a/roles/node/tasks/config-subnets.yml
+++ b/roles/node/tasks/config-subnets.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Generate subnets JSON config files
   copy:

--- a/roles/node/tasks/install-avalanchego.yml
+++ b/roles/node/tasks/install-avalanchego.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: "Create {{ avalanchego_user }} user"
   user:

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}
   debug:

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Install AvalancheGo
   include_tasks: install-avalanchego.yml

--- a/roles/node/tasks/prefunded-account.yml
+++ b/roles/node/tasks/prefunded-account.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Wait for blockchains to be bootstrapped
   uri:

--- a/roles/node/tasks/start.yml
+++ b/roles/node/tasks/start.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Restart AvalancheGo and reload VMs if needed
   meta: flush_handlers

--- a/roles/node/templates/aliases.json.j2
+++ b/roles/node/templates/aliases.json.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2022, Gauthier Leonard
-See the file LICENSE for licensing terms. #}
+{# SPDX-License-Identifier: BSD-3-Clause
+Copyright (c) 2022-2023, E36 Knots #}
 {
   {% for vm in avalanchego_vms_install %}
   {% set vm_name = vm.split('=')[0] %}

--- a/roles/node/templates/avalanchego.service.j2
+++ b/roles/node/templates/avalanchego.service.j2
@@ -1,5 +1,5 @@
-{# Copyright (C) 2022, Gauthier Leonard
-See the file LICENSE for licensing terms. #}
+{# SPDX-License-Identifier: BSD-3-Clause
+Copyright (c) 2022-2023, E36 Knots #}
 [Unit]
 Description=AvalancheGo systemd service
 StartLimitIntervalSec=0

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 # Avalanchego version
 avalanchego_binary_name: "avalanchego-linux-amd64-v{{ avalanchego_version }}.tar.gz"

--- a/roles/subnet/defaults/main.yml
+++ b/roles/subnet/defaults/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 # Network
 avalanchego_http_host: 127.0.0.1

--- a/roles/subnet/tasks/main.yml
+++ b/roles/subnet/tasks/main.yml
@@ -1,5 +1,5 @@
-# Copyright (C) 2022, Gauthier Leonard
-# See the file LICENSE for licensing terms.
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Wait for P-Chain to be bootstrapped
   uri:

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -1,5 +1,8 @@
 #!/bin/python3
 
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+
 import os
 import requests
 import re


### PR DESCRIPTION
### Linked issues

- Fixes #17 

### Changes
- Uniformize licence headers + move ownership to `E36 Knots`