### PR TITLE
fix: clean plugins dir if avalanchego_vms_install is empty

### DIFF
--- a/roles/node/tasks/clean-plugins-dir.yml
+++ b/roles/node/tasks/clean-plugins-dir.yml
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+- name: List links in {{ avalanchego_plugins_dir }}
+  find:
+    paths: "{{ avalanchego_plugins_dir }}"
+    file_type: link
+  register: links
+
+- name: Remove outdated links in {{ avalanchego_plugins_dir }}
+  file:
+    path: "{{ item.path }}"
+    state: absent
+  when: item.path | basename not in avalanchego_vms_install | join
+  no_log: true
+  with_items: "{{ links.files }}"

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -4,6 +4,9 @@
 - name: Install AvalancheGo
   include_tasks: install-avalanchego.yml
 
+- name: Clean plugins dir
+  include_tasks: clean-plugins-dir.yml
+
 - name: Install VMs
   include_tasks: install-vm.yml
   vars:


### PR DESCRIPTION
### Linked issues

Fix #27 

### Changes

Added a `clean-plugins-dir.yml` task triggered when `avalanchego_vms_install` is empty.
