### PR TITLE
feat: drop support for vms other than subnet-evm

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ namespace: ash
 name: avalanche
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.4.1
+version: 0.5.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md
@@ -47,9 +47,6 @@ repository: https://github.com/AshAvalanche/ansible-avalanche-collection
 
 # The URL to any online docs
 documentation: https://docs.ash.center/docs/tools/ansible-avalanche-collection/overview
-
-# The URL to the homepage of the collection/project
-homepage: http://example.com
 
 # The URL to the collection issue tracker
 issues: https://github.com/AshAvalanche/ansible-avalanche-collection/issues

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -68,25 +68,17 @@ To install a VM on the node, add it to `avalanchego_vms_install` following `VM_N
 
 ### Available VMs and AvalancheGo compatibility
 
-List of VMs currently available for install:
+List of VMs currently available for installation:
 
-- `blobvm`: The [Blob Virtual Machine](https://github.com/ava-labs/blobvm) in all versions
-- `spacesvm`: The [Spaces Virtual Machine](https://github.com/ava-labs/spacesvm) in all versions
-- `subnetevm`: The [Subnet EVM](https://github.com/ava-labs/subnet-evm) in all versions
-- `timestampvm`: The [Timestamp Virtual Machine](https://github.com/ava-labs/timestampvm) in versions `1.2.0` and later
+- `subnetevm`: The [Subnet EVM](https://github.com/ava-labs/subnet-evm) in versions `0.4.8` or later
 
 Here is the compatibility matrix with AvalancheGo versions:
 
-| AvalancheGo     | `blobvm`      | `spacesvm`    | `subnetevm`   | `timestampvm` |
-| --------------- | ------------- | ------------- | ------------- | ------------- |
-| `1.7.0-1.7.4`   | -             | `0.0.1`       | `0.1.0`       | `1.2.0`       |
-| `1.7.5-1.7.6`   | -             | `0.0.2`       | `0.1.1-0.1.2` | `1.2.2`       |
-| `1.7.7-1.7.9`   | `0.0.1-0.0.2` | `0.0.3`       | `0.2.0`       | `1.2.3`       |
-| `1.7.10`        | `0.0.3`       | `0.0.4`       | `0.2.1`       | `1.2.4`       |
-| `1.7.11-1.7.12` | `0.0.4`       | `0.0.5`       | `0.2.2`       | `1.2.5`       |
-| `1.7.13-1.7.18` | `0.0.5-0.0.7` | `0.0.6-0.0.7` | `0.2.3-0.2.5` | `1.2.6`       |
-| `1.8.0-1.8.6`   | `0.0.8`       | `0.0.8`       | `0.3.0`       | -             |
-| `1.9.0`         | `0.0.9`       | `0.0.9`       | `0.4.0`       | -             |
+| AvalancheGo   | `subnetevm`     |
+| ------------- | --------------- |
+| `1.9.6-1.9.8` | `0.4.8`         |
+| `1.9.9`       | `0.4.9-0.4.10`  |
+| `1.9.10`      | `0.4.11-0.4.12` |
 
 **Note:** If a versions incompatibility is detected, an error message will be prompted and the role execution will stop.
 

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -46,7 +46,7 @@ avalanchego_vms_install: []
 ##  - spacesvm=0.0.15
 
 # Ash protocol (https://ash.center)
-## If set to yes, will enrich the node configuration with on-chain information
+## If set to `yes`, will enrich the node configuration with on-chain information
 ## Warning: If the node is not known to the Ash protocol the role will fail
 ash_node: no
 

--- a/roles/node/tasks/install-avalanchego.yml
+++ b/roles/node/tasks/install-avalanchego.yml
@@ -1,6 +1,12 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
+- name: Check that AvalancheGo {{ avalanchego_version }} is supported
+  debug:
+    msg: "AvalancheGo {{ avalanchego_version }} >= {{ avalanchego_min_version }}"
+  run_once: yes
+  failed_when: not avalanchego_version is version(avalanchego_min_version, 'ge')
+
 - name: "Create {{ avalanchego_user }} user"
   user:
     name: "{{ avalanchego_user }}"

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -2,6 +2,7 @@
 # Copyright (c) 2022-2023, E36 Knots
 ---
 # Avalanchego version
+avalanchego_min_version: 1.9.6
 avalanchego_binary_name: "avalanchego-linux-amd64-v{{ avalanchego_version }}.tar.gz"
 avalanchego_binary_url: "https://github.com/ava-labs/avalanchego/releases/download/v{{ avalanchego_version }}/{{ avalanchego_binary_name }}"
 
@@ -27,98 +28,6 @@ avalanche_networks:
 
 # List of VMs supported by the collection
 avalanchego_vms_list:
-  blobvm:
-    aliases:
-      - blobvm
-    binary_prefix: blobvm-linux-amd64
-    download_url: https://github.com/AshAvalanche/blobvm/releases/download
-    id: kM6h4LYe3AcEU1MB2UNg6ubzAiDAALZzpVrbX8zn3hXF6Avd8
-    versions_comp:
-      0.0.1:
-        ge: 1.7.7
-        le: 1.7.9
-      0.0.2:
-        ge: 1.7.7
-        le: 1.7.9
-      0.0.3:
-        ge: 1.7.10
-        le: 1.7.10
-      0.0.4:
-        ge: 1.7.11
-        le: 1.7.12
-      0.0.5:
-        ge: 1.7.13
-        le: 1.7.18
-      0.0.6:
-        ge: 1.7.13
-        le: 1.7.18
-      0.0.7:
-        ge: 1.7.13
-        le: 1.7.18
-      0.0.8:
-        ge: 1.8.0
-        le: 1.8.6
-      0.0.9:
-        ge: 1.9.0
-        le: 1.9.0
-      0.0.10:
-        ge: 1.9.1
-        le: 1.9.2
-      0.0.11:
-        ge: 1.9.1
-        le: 1.9.3
-  spacesvm:
-    aliases:
-      - spacesvm
-    binary_prefix: spacesvm-linux-amd64
-    download_url: https://github.com/AshAvalanche/spacesvm/releases/download
-    id: sqja3uK17MJxfC7AN8nGadBw9JK5BcrsNwNynsqP5Gih8M5Bm
-    versions_comp:
-      0.0.1:
-        ge: 1.7.0
-        le: 1.7.4
-      0.0.2:
-        ge: 1.7.5
-        le: 1.7.6
-      0.0.3:
-        ge: 1.7.7
-        le: 1.7.9
-      0.0.4:
-        ge: 1.7.10
-        le: 1.7.10
-      0.0.5:
-        ge: 1.7.11
-        le: 1.7.12
-      0.0.6:
-        ge: 1.7.13
-        le: 1.7.18
-      0.0.7:
-        ge: 1.7.13
-        le: 1.7.18
-      0.0.8:
-        ge: 1.8.0
-        le: 1.8.6
-      0.0.9:
-        ge: 1.9.0
-        le: 1.9.1
-      0.0.10:
-        ge: 1.9.2
-        le: 1.9.2
-      0.0.11:
-        ge: 1.9.2
-        le: 1.9.2
-      0.0.12:
-        ge: 1.9.3
-        le: 1.9.3
-      0.0.13:
-        ge: 1.9.4
-        le: 1.9.4
-      0.0.14:
-        ge: 1.9.4
-        le: 1.9.4
-      0.0.15:
-        ge: 1.9.6
-        le: 1.9.7
   subnetevm:
     aliases:
       - subnetevm
@@ -129,72 +38,6 @@ avalanchego_vms_list:
     genesis_rpc_extra_path: /rpc
     id: spePNvBxaWSYL2tB5e2xMmMNBQkXMN8z2XEbz1ML2Aahatwoc
     versions_comp:
-      0.1.0:
-        ge: 1.7.0
-        le: 1.7.4
-      0.1.1:
-        ge: 1.7.5
-        le: 1.7.6
-      0.1.2:
-        ge: 1.7.5
-        le: 1.7.6
-      0.2.0:
-        ge: 1.7.7
-        le: 1.7.9
-      0.2.1:
-        ge: 1.7.10
-        le: 1.7.10
-      0.2.2:
-        ge: 1.7.11
-        le: 1.7.12
-      0.2.3:
-        ge: 1.7.13
-        le: 1.7.16
-      0.2.4:
-        ge: 1.7.13
-        le: 1.7.16
-      0.2.5:
-        ge: 1.7.13
-        le: 1.7.16
-      0.2.6:
-        ge: 1.7.13
-        le: 1.7.16
-      0.2.7:
-        ge: 1.7.13
-        le: 1.7.16
-      0.2.8:
-        ge: 1.7.13
-        le: 1.7.18
-      0.2.9:
-        ge: 1.7.13
-        le: 1.7.18
-      0.3.0:
-        ge: 1.8.0
-        le: 1.8.6
-      0.4.0:
-        ge: 1.9.0
-        le: 1.9.0
-      0.4.1:
-        ge: 1.9.1
-        le: 1.9.1
-      0.4.2:
-        ge: 1.9.1
-        le: 1.9.1
-      0.4.3:
-        ge: 1.9.2
-        le: 1.9.2
-      0.4.4:
-        ge: 1.9.2
-        le: 1.9.3
-      0.4.5:
-        ge: 1.9.4
-        le: 1.9.4
-      0.4.6:
-        ge: 1.9.4
-        le: 1.9.4
-      0.4.7:
-        ge: 1.9.5
-        le: 1.9.5
       0.4.8:
         ge: 1.9.6
         le: 1.9.8
@@ -204,46 +47,9 @@ avalanchego_vms_list:
       0.4.10:
         ge: 1.9.9
         le: 1.9.9
-  timestampvm:
-    aliases:
-      - timestampvm
-    binary_prefix: timestampvm-linux-amd64
-    download_url: https://github.com/AshAvalanche/timestampvm/releases/download
-    genesis_build_method: timestampvm.encode
-    genesis_json_key: bytes
-    genesis_rpc_extra_path: ""
-    id: tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH
-    versions_comp:
-      1.2.0:
-        ge: 1.7.0
-        le: 1.7.4
-      1.2.1:
-        ge: 1.7.0
-        le: 1.7.4
-      1.2.2:
-        ge: 1.7.5
-        le: 1.7.6
-      1.2.3:
-        ge: 1.7.7
-        le: 1.7.9
-      1.2.4:
-        ge: 1.7.10
-        le: 1.7.10
-      1.2.5:
-        ge: 1.7.11
-        le: 1.7.12
-      1.2.6:
-        ge: 1.7.13
-        le: 1.7.18
-      1.2.7:
-        ge: 1.9.0
-        le: 1.9.0
-      1.2.8:
-        ge: 1.9.1
-        le: 1.9.1
-      1.2.9:
-        ge: 1.9.2
-        le: 1.9.2
-      1.3.0:
-        ge: 1.9.3
-        le: 1.9.3
+      0.4.11:
+        ge: 1.9.10
+        le: 1.9.10
+      0.4.12:
+        ge: 1.9.10
+        le: 1.9.10


### PR DESCRIPTION
### Linked issues

- Fixes #29 

### Changes

- Remove information about unsupported VMs and/or versions
- Test the target AvalancheGo version before deployement
