### PR TITLE
Use Ava Labs VM releases

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ namespace: ash
 name: avalanche
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.5.0
+version: 0.5.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/blockchain/defaults/main.yml
+++ b/roles/blockchain/defaults/main.yml
@@ -11,9 +11,44 @@ subnet_control_username: ewoq
 subnet_control_password: I_l1ve_@_Endor
 
 # Blockchain
-blockchain_vm: timestampvm
-blockchain_name: Timestamp Chain
+blockchain_vm: subnet-evm
+blockchain_name: Subnet EVM
 blockchain_aliases:
-  - timestamp
+  - subnet-evm
 blockchain_genesis_params:
-  data: Hello world
+  genesisData:
+    config:
+      chainId: 13213
+      homesteadBlock: 0
+      eip150Block: 0
+      eip150Hash: "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"
+      eip155Block: 0
+      eip158Block: 0
+      byzantiumBlock: 0
+      constantinopleBlock: 0
+      petersburgBlock: 0
+      istanbulBlock: 0
+      muirGlacierBlock: 0
+      subnetEVMTimestamp: 0
+      feeConfig:
+        gasLimit: 8000000
+        minBaseFee: 25000000000
+        targetGas: 15000000
+        baseFeeChangeDenominator: 36
+        minBlockGasCost: 0
+        maxBlockGasCost: 1000000
+        targetBlockRate: 2
+        blockGasCostStep: 200000
+    alloc:
+      8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC:
+        balance: "0x295BE96E64066972000000"
+    nonce: "0x0"
+    timestamp: "0x0"
+    extraData: "0x00"
+    gasLimit: "0x7A1200"
+    difficulty: "0x0"
+    mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+    coinbase: "0x0000000000000000000000000000000000000000"
+    number: "0x0"
+    gasUsed: "0x0"
+    parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000"

--- a/roles/node/README.md
+++ b/roles/node/README.md
@@ -70,11 +70,11 @@ To install a VM on the node, add it to `avalanchego_vms_install` following `VM_N
 
 List of VMs currently available for installation:
 
-- `subnetevm`: The [Subnet EVM](https://github.com/ava-labs/subnet-evm) in versions `0.4.8` or later
+- `subnet-evm`: The [Subnet EVM](https://github.com/ava-labs/subnet-evm) in versions `0.4.8` or later
 
 Here is the compatibility matrix with AvalancheGo versions:
 
-| AvalancheGo   | `subnetevm`     |
+| AvalancheGo   | `subnet-evm`    |
 | ------------- | --------------- |
 | `1.9.6-1.9.8` | `0.4.8`         |
 | `1.9.9`       | `0.4.9-0.4.10`  |

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -18,8 +18,9 @@ avalanchego_certs_dir: /etc/avalanche/avalanchego/staking
 # Log directory
 avalanchego_log_dir: /var/log/avalanche/avalanchego
 
-# User
+# User and group
 avalanchego_user: avalanche
+avalanchego_group: avalanche
 
 # Network
 avalanchego_use_static_ip: yes

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -42,7 +42,7 @@ avalanche_tracked_subnets: []
 # VMs
 avalanchego_vms_install: []
 ## Example
-##  - subnetevm=0.4.10
+##  - subnet-evm=0.4.10
 ##  - timestampvm=1.3.0
 ##  - spacesvm=0.0.15
 

--- a/roles/node/tasks/bootstrap-db.yml
+++ b/roles/node/tasks/bootstrap-db.yml
@@ -6,5 +6,5 @@
     src: "{{ avalanchego_bootstrap_db }}"
     dest: "{{ avalanchego_db_dir }}"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
     creates: "{{ avalanchego_db_dir }}/{{ avalanchego_network_id }}"

--- a/roles/node/tasks/clean-plugins-dir.yml
+++ b/roles/node/tasks/clean-plugins-dir.yml
@@ -7,10 +7,10 @@
     file_type: link
   register: links
 
-- name: Remove outdated links in {{ avalanchego_plugins_dir }}
+- name: "Remove outdated links in {{ avalanchego_plugins_dir }}"
   file:
     path: "{{ item.path }}"
     state: absent
-  when: item.path | basename not in avalanchego_vms_install | join
+  when: (item.path | basename) not in (avalanchego_vms_install | join)
   no_log: true
   with_items: "{{ links.files }}"

--- a/roles/node/tasks/config-chains.yml
+++ b/roles/node/tasks/config-chains.yml
@@ -6,7 +6,7 @@
     path: "{{ avalanchego_chains_conf_dir }}/{{ item }}"
     state: directory
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   loop: "{{ avalanchego_chains_configs.keys() }}"
 
 - name: Generate chains config.json
@@ -14,6 +14,6 @@
     content: "{{ item.value | to_nice_json }}\n"
     dest: "{{ avalanchego_chains_conf_dir }}/{{ item.key }}/config.json"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   loop: "{{ avalanchego_chains_configs | dict2items }}"
   notify: Restart avalanchego

--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -44,7 +44,7 @@
     content: "{{ node_conf_json | to_nice_json(indent=2) }}\n"
     dest: "{{ avalanchego_conf_dir }}/node.json"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   notify: Restart avalanchego
 
 - name: Upload nodes certificates
@@ -52,7 +52,7 @@
     src: "{{ avalanchego_local_certs_dir }}/{{ inventory_hostname }}.{{ item }}"
     dest: "{{ avalanchego_certs_dir }}/staker.{{ item }}"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   loop:
     - crt
     - key
@@ -65,5 +65,5 @@
     dest: "{{ avalanchego_vms_conf_dir }}/aliases.json"
     lstrip_blocks: yes
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   notify: New VM

--- a/roles/node/tasks/config-subnets.yml
+++ b/roles/node/tasks/config-subnets.yml
@@ -6,6 +6,6 @@
     content: "{{ item.value | to_nice_json }}\n"
     dest: "{{ avalanchego_subnets_conf_dir }}/{{ item.key }}.json"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   loop: "{{ avalanchego_subnets_configs | dict2items }}"
   notify: Restart avalanchego

--- a/roles/node/tasks/install-avalanchego.yml
+++ b/roles/node/tasks/install-avalanchego.yml
@@ -1,22 +1,27 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: Check that AvalancheGo {{ avalanchego_version }} is supported
+- name: "Check that AvalancheGo {{ avalanchego_version }} is supported"
   debug:
     msg: "AvalancheGo {{ avalanchego_version }} >= {{ avalanchego_min_version }}"
   run_once: yes
   failed_when: not avalanchego_version is version(avalanchego_min_version, 'ge')
 
+- name: "Create {{ avalanchego_group }} group"
+  group:
+    name: "{{ avalanchego_group }}"
+
 - name: "Create {{ avalanchego_user }} user"
   user:
     name: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
 
 - name: Create AvalancheGo dirs
   file:
     path: "{{ item }}"
     state: directory
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   loop:
     - "{{ avalanchego_plugins_dir }}"
     - "{{ avalanchego_releases_dir }}"
@@ -36,14 +41,14 @@
     url: "{{ avalanchego_binary_url }}"
     dest: "{{ avalanchego_releases_dir }}/{{ avalanchego_binary_name }}"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
 
 - name: "Unpack AvalancheGo {{ avalanchego_version }} binary"
   unarchive:
     src: "{{ avalanchego_releases_dir }}/{{ avalanchego_binary_name }}"
     dest: "{{ avalanchego_install_dir }}"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
     remote_src: yes
     creates: "{{ avalanchego_install_dir }}/avalanchego-v{{ avalanchego_version }}"
 
@@ -53,7 +58,7 @@
     dest: "{{ avalanchego_current_dir }}/avalanchego"
     state: link
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   notify: Restart avalanchego
 
 - name: Template avalanchego.service file

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -1,25 +1,21 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}
+- name: "Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}"
   debug:
     msg: "AvalancheGo version {{ item.key }} {{ item.value }}: {{ avalanchego_version is version(item.value, item.key) }}"
   run_once: yes
   loop: "{{ vm_info.versions_comp[vm_version] | dict2items }}"
   failed_when: not avalanchego_version is version(item.value, item.key)
 
-- name: Construct {{ vm_name }} binary filename
-  set_fact:
-    vm_binary_name: "{{ vm_info.binary_prefix }}-v{{ vm_version }}.tar.gz"
-
-- name: Create {{ vm_name }} dir
+- name: "Create {{ vm_name }} dir"
   file:
     path: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases"
     state: directory
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
 
-- name: Download {{ vm_name }} binary
+- name: "Download {{ vm_name }} {{ vm_version }} binary"
   get_url:
     url: "{{ vm_info.download_url }}/v{{ vm_version }}/{{ vm_binary_name }}"
     dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
@@ -27,20 +23,20 @@
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_user }}"
 
-- name: Unpack {{ vm_name }} binary
+- name: "Unpack {{ vm_name }} binary"
   unarchive:
     src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
     dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}"
     remote_src: yes
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
-    creates: "{{ avalanchego_vms_dir }}/{{ vm_name}}/{{ vm_name }}-v{{ vm_version }}"
+    group: "{{ avalanchego_group }}"
+    creates: "{{ avalanchego_vms_dir }}/{{ vm_name}}/{{ vm_name }}-v{{ vm_version }}/{{ vm_name }}"
 
-- name: Create the symlink to {{ vm_name }} binary in plugins dir
+- name: "Create the symlink to {{ vm_name }} binary in plugins dir"
   file:
     src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/{{ vm_name }}-v{{ vm_version }}/{{ vm_name }}"
     dest: "{{ avalanchego_plugins_dir }}/{{ vm_name }}"
     state: link
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
   notify: New VM

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -17,16 +17,23 @@
 
 - name: "Download {{ vm_name }} {{ vm_version }} binary"
   get_url:
-    url: "{{ vm_info.download_url }}/v{{ vm_version }}/{{ vm_binary_name }}"
-    dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
-    checksum: "sha512:{{ vm_info.download_url }}/v{{ vm_version }}/{{ vm_binary_name }}.sha512"
+    url: "{{ vm_info.download_url }}/v{{ vm_version }}/{{ avalanchego_vm_binary_filename }}"
+    dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ avalanchego_vm_binary_filename }}"
+    checksum: "sha256:{{ vm_info.download_url }}/v{{ vm_version }}/{{ avalanchego_vm_checksum_filename }}"
     owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
+
+- name: "Create {{ vm_name }}-v{{ vm_version }} directory"
+  file:
+    path: "{{ avalanchego_vms_dir }}/{{ vm_name }}/{{ vm_name }}-v{{ vm_version }}"
+    state: directory
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
 
 - name: "Unpack {{ vm_name }} binary"
   unarchive:
-    src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ vm_binary_name }}"
-    dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}"
+    src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/releases/{{ avalanchego_vm_binary_filename }}"
+    dest: "{{ avalanchego_vms_dir }}/{{ vm_name }}/{{ vm_name }}-v{{ vm_version }}"
     remote_src: yes
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -26,13 +26,16 @@ avalanche_networks:
       explorer_api: https://api-testnet.snowtrace.io/api
       ash_router_addr: "0xB41b15Dc8C0Cd5A019e9F91ad5763Fb4aC571378"
 
+# String templates for VM files to download
+avalanchego_vm_binary_filename: "{{ vm_name }}_{{ vm_version }}_linux_amd64.tar.gz"
+avalanchego_vm_checksum_filename: "{{ vm_name }}_{{ vm_version }}_checksums.txt"
+
 # List of VMs supported by the collection
 avalanchego_vms_list:
-  subnetevm:
+  subnet-evm:
     aliases:
-      - subnetevm
-    binary_prefix: subnetevm-linux-amd64
-    download_url: https://github.com/AshAvalanche/subnet-evm/releases/download
+      - subnet-evm
+    download_url: https://github.com/ava-labs/subnet-evm/releases/download
     genesis_build_method: subnetevm.buildGenesis
     genesis_json_key: genesisBytes
     genesis_rpc_extra_path: /rpc

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -18,7 +18,7 @@ GITHUB_API_URL = 'https://api.github.com'
 VARS_YAML_PATH = '../roles/node/vars/main.yml'
 VARS_YAML_HEADER_SIZE = 3
 VMS_REPOS = {
-    'subnetevm': 'AshAvalanche/subnet-evm',
+    'subnet-evm': 'ava-labs/subnet-evm',
 }
 MIN_AVAX_VERSION = '1.9.6'
 


### PR DESCRIPTION
### Linked issues

- Fixes #32 

### Changes

- Use releases from Ava Labs repository instead of our own
- Change the default VM for creating a blockchain to Subnet EVM
- Add the possibility to customize the AvalancheGo user group
- Bump collection version to `0.5.1`