### PR TITLE
feat: add ash_cli role

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -11,7 +11,7 @@ namespace: ash
 name: avalanche
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 0.7.0
+version: 0.7.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/playbooks/bootstrap_local_network.yml
+++ b/playbooks/bootstrap_local_network.yml
@@ -5,12 +5,14 @@
   hosts: bootstrap_node
   become: true
   roles:
+    - role: ash.avalanche.ash_cli
     - role: ash.avalanche.node
 
 - name: Provision other network nodes
   hosts: avalanche_nodes:!bootstrap_node
   become: true
   roles:
+    - role: ash.avalanche.ash_cli
     - role: ash.avalanche.node
 
 - name: Provision prefunded account on bootstrap node

--- a/playbooks/provision_nodes.yml
+++ b/playbooks/provision_nodes.yml
@@ -5,4 +5,5 @@
   hosts: avalanche_nodes
   become: true
   roles:
+    - role: ash.avalanche.ash_cli
     - role: ash.avalanche.node

--- a/roles/ash_cli/defaults/main.yml
+++ b/roles/ash_cli/defaults/main.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+# Ash CLI version
+ash_cli_version: 0.1.0
+
+# Install directories
+ash_cli_install_dir: /opt/avalanche/ash-cli

--- a/roles/ash_cli/tasks/install.yml
+++ b/roles/ash_cli/tasks/install.yml
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+- name: Create Ash CLI directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+  loop:
+    - "{{ ash_cli_install_dir }}"
+
+- name: "Download Ash CLI {{ ash_cli_version }} binary"
+  get_url:
+    url: "{{ ash_cli_binary_url }}"
+    dest: "{{ ash_cli_install_dir }}/{{ ash_cli_binary_name }}"
+    checksum: "sha512:{{ ash_cli_binary_url }}.sha512"
+    owner: root
+    group: root
+    mode: 0755
+
+- name: "Create the symlink to Ash CLI {{ ash_cli_version }} binary"
+  file:
+    src: "{{ ash_cli_install_dir }}/{{ ash_cli_binary_name }}"
+    dest: /usr/local/bin/ash
+    state: link
+    owner: root
+    group: root

--- a/roles/ash_cli/tasks/main.yml
+++ b/roles/ash_cli/tasks/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+- name: Install Ash CLI
+  include_tasks: install.yml

--- a/roles/ash_cli/vars/main.yml
+++ b/roles/ash_cli/vars/main.yml
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+ash_cli_binary_name: "ash-linux-amd64-v{{ ash_cli_version }}"
+ash_cli_binary_url: "https://github.com/AshAvalanche/ash-rs/releases/download/v{{ ash_cli_version }}/{{ ash_cli_binary_name }}"

--- a/roles/blockscout/tasks/config-blockscout.yml
+++ b/roles/blockscout/tasks/config-blockscout.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier:  BUSL-1.1
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: Create Blockscout dirs
+- name: Create Blockscout directories
   file:
     path: "{{ item }}"
     state: directory

--- a/roles/faucet/tasks/install-faucet.yml
+++ b/roles/faucet/tasks/install-faucet.yml
@@ -12,7 +12,7 @@
       - "{{ avalanche_faucet_group }}"
       - "{{ avalanche_faucet_docker_group }}"
 
-- name: Create Avalanche Faucet dirs
+- name: Create Avalanche Faucet directories
   file:
     path: "{{ item }}"
     state: directory

--- a/roles/node/tasks/config-chains.yml
+++ b/roles/node/tasks/config-chains.yml
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: Create chains conf dirs
+- name: Create chains conf directories
   file:
     path: "{{ avalanchego_chains_conf_dir }}/{{ item }}"
     state: directory

--- a/roles/node/tasks/install-avalanchego.yml
+++ b/roles/node/tasks/install-avalanchego.yml
@@ -16,7 +16,7 @@
     name: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"
 
-- name: Create AvalancheGo dirs
+- name: Create AvalancheGo directories
   file:
     path: "{{ item }}"
     state: directory


### PR DESCRIPTION
### Linked issues

None

### Changes

- Add the `ash_cli` role that installs the Ash CLI from [ash-rs](https://github.com/AshAvalanche/ash-rs) releases

### Additional comments

In the future, this role could also template Ash configuration files depending on the network.
