### PR TITLE
feat(ash_cli): add config playbook

### DIFF
--- a/roles/ash_cli/defaults/main.yml
+++ b/roles/ash_cli/defaults/main.yml
@@ -2,7 +2,13 @@
 # Copyright (c) 2022-2023, E36 Knots
 ---
 # Ash CLI version
-ash_cli_version: 0.1.0
+ash_cli_version: 0.1.1
 
-# Install directories
+# Directories
 ash_cli_install_dir: /opt/avalanche/ash-cli
+ash_cli_conf_dir: /etc/avalanche/ash-cli/conf
+
+# Avalanche context
+avalanche_network_id: fuji
+## Only used if `avalanche_network_id` is `local`
+avalanche_pchain_local_url: http://127.0.0.1:9650/ext/bc/P

--- a/roles/ash_cli/tasks/config.yml
+++ b/roles/ash_cli/tasks/config.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+- name: Initialize the default Ash CLI configuration
+  command:
+    cmd: ash conf init --config {{ ash_cli_conf_dir }}/default.yml
+    creates: "{{ ash_cli_conf_dir }}/default.yml"
+
+- name: Add local network configuration
+  blockinfile:
+    path: "{{ ash_cli_conf_dir }}/default.yml"
+    block: |
+      - name: local
+        subnets:
+        - id: 11111111111111111111111111111111LpoYY
+          controlKeys: []
+          threshold: 0
+          blockchains:
+          - id: 11111111111111111111111111111111LpoYY
+            name: P-Chain
+            vmId: 11111111111111111111111111111111LpoYY
+            vmType: PVM
+            rpcUrl: {{ avalanche_pchain_local_url }}
+    insertafter: "avalancheNetworks:"
+  when: avalanche_network_id == "local"

--- a/roles/ash_cli/tasks/install.yml
+++ b/roles/ash_cli/tasks/install.yml
@@ -8,12 +8,14 @@
     owner: root
     group: root
   loop:
-    - "{{ ash_cli_install_dir }}"
+    - "{{ ash_cli_releases_dir }}"
+    - "{{ ash_cli_bin_dir }}"
+    - "{{ ash_cli_conf_dir }}"
 
 - name: "Download Ash CLI {{ ash_cli_version }} binary"
   get_url:
     url: "{{ ash_cli_binary_url }}"
-    dest: "{{ ash_cli_install_dir }}/{{ ash_cli_binary_name }}"
+    dest: "{{ ash_cli_releases_dir }}/{{ ash_cli_binary_name }}"
     checksum: "sha512:{{ ash_cli_binary_url }}.sha512"
     owner: root
     group: root
@@ -21,8 +23,16 @@
 
 - name: "Create the symlink to Ash CLI {{ ash_cli_version }} binary"
   file:
-    src: "{{ ash_cli_install_dir }}/{{ ash_cli_binary_name }}"
-    dest: /usr/local/bin/ash
+    src: "{{ ash_cli_releases_dir }}/{{ ash_cli_binary_name }}"
+    dest: "{{ ash_cli_bin_dir }}/ash"
     state: link
     owner: root
     group: root
+
+- name: Template ash command
+  template:
+    src: ash-command.j2
+    dest: /usr/local/bin/ash
+    owner: root
+    group: root
+    mode: 0755

--- a/roles/ash_cli/tasks/main.yml
+++ b/roles/ash_cli/tasks/main.yml
@@ -3,3 +3,6 @@
 ---
 - name: Install Ash CLI
   include_tasks: install.yml
+
+- name: Configure Ash CLI
+  include_tasks: config.yml

--- a/roles/ash_cli/templates/ash-command.j2
+++ b/roles/ash_cli/templates/ash-command.j2
@@ -2,4 +2,4 @@
 Copyright (c) 2022-2023, E36 Knots #}
 #!/bin/bash
 
-ASH_CONF={{ ash_cli_conf_dir }}/default.yml AVALANCHE_NETWORK={{ avalanche_network_id }} {{ ash_cli_bin_dir }}/ash "$@"
+ASH_CONFIG={{ ash_cli_conf_dir }}/default.yml AVALANCHE_NETWORK={{ avalanche_network_id }} {{ ash_cli_bin_dir }}/ash "$@"

--- a/roles/ash_cli/templates/ash-command.j2
+++ b/roles/ash_cli/templates/ash-command.j2
@@ -1,0 +1,5 @@
+{# SPDX-License-Identifier: BSD-3-Clause
+Copyright (c) 2022-2023, E36 Knots #}
+#!/bin/bash
+
+ASH_CONF={{ ash_cli_conf_dir }}/default.yml AVALANCHE_NETWORK={{ avalanche_network_id }} {{ ash_cli_bin_dir }}/ash "$@"

--- a/roles/ash_cli/vars/main.yml
+++ b/roles/ash_cli/vars/main.yml
@@ -3,3 +3,7 @@
 ---
 ash_cli_binary_name: "ash-linux-amd64-v{{ ash_cli_version }}"
 ash_cli_binary_url: "https://github.com/AshAvalanche/ash-rs/releases/download/v{{ ash_cli_version }}/{{ ash_cli_binary_name }}"
+
+# Install directories
+ash_cli_releases_dir: "{{ ash_cli_install_dir }}/releases"
+ash_cli_bin_dir: "{{ ash_cli_install_dir }}/bin"


### PR DESCRIPTION
### Linked issues

- Fixes #53 

### Dependencies

- https://github.com/AshAvalanche/ash-rs/pull/35

### Changes

- Add the `config` playbook to the `ash_cli` role. This allows defining a default configuration through environment variables, especially for local networks that have a changing P-Chain endpoint

### Additional comments

Note that the `--config` argument takes preference over the configuration provided through env variables.