### PR TITLE
feat: avalanchego_node_json precedence in combine

### DIFF
--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -40,13 +40,12 @@
 - name: Construct node.json conf
   set_fact:
     node_conf_json: |
-      {{ avalanchego_node_json |
-         combine(
-           node_conf_public_ip,
-           node_conf_bootstrap,
-           node_conf_staking_tls_files,
-           node_conf_http_tls_files
-         ) }}
+      {{ (
+        node_conf_public_ip,
+        node_conf_bootstrap,
+        node_conf_staking_tls_files,
+        node_conf_http_tls_files
+        ) | combine(avalanchego_node_json) }}
 
 - name: Generate node.json
   copy:


### PR DESCRIPTION
### Linked issues

- Fix #76 

### Changes

- Switched `avalanchego_node_json` in the `combine` filter to let the already defined keys keep their values