### PR TITLE
Fix add-validator vars propagation

### DIFF
--- a/plugins/modules/ash_cmd.py
+++ b/plugins/modules/ash_cmd.py
@@ -18,7 +18,14 @@ def run_module():
     module_args = dict(
         command=dict(type="list", required=True),
         options=dict(type="dict", required=False, default={}),
-        ash_path=dict(type="str", required=False, default="/usr/local/bin/ash"),
+        ash_path=dict(
+            type="str", required=False, default="/opt/avalanche/ash-cli/bin/ash"
+        ),
+        ash_config=dict(
+            type="str",
+            required=False,
+            default="/etc/avalanche/ash-cli/conf/default.yml",
+        ),
         json=dict(type="bool", required=False, default=True),
     )
 
@@ -46,7 +53,7 @@ def run_module():
         if value is False:
             continue
         command.append("--" + key)
-        # if value is boolean true, then it's a flag:
+        # if value is boolean true, then it's a flag
         if value is True:
             continue
         # if value is int, cast to string
@@ -59,6 +66,10 @@ def run_module():
     # force json output
     if module.params["json"]:
         command.append("--json")
+
+    # add the config flag
+    command.append("--config")
+    command.append(module.params["ash_config"])
 
     # run the command
     run = module.run_command(" ".join(command))

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -96,21 +96,21 @@ avalanchego_chains_configs:
   C:
     state-sync-enabled: true
 
-# Validator configuration (for the Primary Network)
+# Validator configuration
 ## Private key used to sign the staking transaction
-subnet_txs_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
+validator_txs_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGztUrTXtNN
 ## Private key encoding (cb58 or hex)
-subnet_txs_key_encoding: cb58
+validator_txs_key_encoding: cb58
 
 ## Validation parameters
-subnet_validator_start_time_command_default: 'date -d ''2 minutes'' --rfc-3339=seconds | tr " " T' # in 2 minutes
-subnet_validator_end_time_command_default: 'date -d ''1 week'' --rfc-3339=seconds | tr " " T' # in 1 week
-subnet_validator_start_time_command_darwin: "date -v+2M '+%Y-%m-%dT%H:%M:%SZ'" # in 2 minutes
-subnet_validator_end_time_command_darwin: "date -v+1w '+%Y-%m-%dT%H:%M:%SZ'" # in 1 week
-subnet_validator_start_time: '{{ lookup("pipe", lookup("vars", "subnet_validator_start_time_command_"+ansible_os_family | lower, default=subnet_validator_start_time_command_default)) }}'
-subnet_validator_end_time: '{{ lookup("pipe", lookup("vars", "subnet_validator_end_time_command_"+ansible_os_family | lower, default=subnet_validator_end_time_command_default)) }}'
-subnet_validator_stake_or_weight: 1 # in AVAX
-subnet_validator_delegation_fee: 2 # in percent
+validator_start_time_command_default: 'date -d ''2 minutes'' --rfc-3339=seconds | tr " " T' # in 2 minutes
+validator_end_time_command_default: 'date -d ''1 week'' --rfc-3339=seconds | tr " " T' # in 1 week
+validator_start_time_command_darwin: "date -v+2M '+%Y-%m-%dT%H:%M:%SZ'" # in 2 minutes
+validator_end_time_command_darwin: "date -v+1w '+%Y-%m-%dT%H:%M:%SZ'" # in 1 week
+validator_start_time: '{{ lookup("pipe", lookup("vars", "validator_start_time_command_"+ansible_os_family | lower, default=validator_start_time_command_default)) }}'
+validator_end_time: '{{ lookup("pipe", lookup("vars", "validator_end_time_command_"+ansible_os_family | lower, default=validator_end_time_command_default)) }}'
+validator_stake_or_weight: 1 # in AVAX
+validator_delegation_fee: 2 # in percent
 
 # Ash CLI configuration
 ## Whether to install and configure Ash CLI on the node

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -23,4 +23,11 @@
     name: ash.avalanche.subnet
     tasks_from: add-validator
   vars:
+    subnet_avalanche_network_id: "{{ avalanchego_network_id }}"
     node_id: "{{ node_info_res.output.id }}"
+    subnet_txs_private_key: "{{ validator_txs_private_key }}"
+    subnet_txs_key_encoding: "{{ validator_txs_key_encoding }}"
+    subnet_validator_start_time: "{{ validator_start_time }}"
+    subnet_validator_end_time: "{{ validator_end_time }}"
+    subnet_validator_stake_or_weight: "{{ validator_stake_or_weight }}"
+    subnet_validator_delegation_fee: "{{ validator_delegation_fee }}"


### PR DESCRIPTION
### Linked issues

- Fixes #80

### Changes

- `avalanche.node`
  - Rename validator vars in the `node` role to avoid overlapping with var names in the `subnet` role
  - Explicitly pass vars in the `include_role` task
- `avalanche.ash_cmd`
  - Directly call the Ash CLI binary instead of the script in `/bin/local`. This is to avoid conflicts in env vars
  - Add the `ash_config` argument