### PR TITLE
Add Ansible tags + allow multiple bootstrap nodes

### DIFF
--- a/playbooks/bootstrap_local_network.yml
+++ b/playbooks/bootstrap_local_network.yml
@@ -1,14 +1,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: Provision bootstrap node
-  hosts: bootstrap_node
+- name: Provision bootstrap nodes
+  hosts: bootstrap_nodes
   become: true
   roles:
     - role: ash.avalanche.node
 
 - name: Provision other network nodes
-  hosts: avalanche_nodes:!bootstrap_node
+  hosts: avalanche_nodes:!bootstrap_nodes
   become: true
   roles:
     - role: ash.avalanche.node

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier:  BUSL-1.1
+# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
 collections:

--- a/roles/ash_cli/tasks/main.yml
+++ b/roles/ash_cli/tasks/main.yml
@@ -2,7 +2,11 @@
 # Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Install Ash CLI
-  include_tasks: install.yml
+  import_tasks: install.yml
+  tags:
+    - install
 
 - name: Configure Ash CLI
-  include_tasks: config.yml
+  import_tasks: config.yml
+  tags:
+    - config

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -47,8 +47,9 @@ avalanchego_staking_local_certs_dir: "{{ playbook_dir }}/files/staking"
 
 # Bootstrapping
 avalanchego_network_id: fuji
-## Node ID of the first validator on `local` networks
-avalanchego_bootstrap_node_id: NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+## Node IDs of the bootstrap nodes on networks other than `mainnet` and `fuji`
+avalanchego_bootstrap_node_ids:
+  - NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
 avalanchego_bootstrap_db: ""
 
 # Subnets

--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -1,10 +1,13 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: Set bootstrap_ip
+- name: Set bootstrap_ips variable
   set_fact:
-    bootstrap_ip: "{{ hostvars[groups['bootstrap_node'][0]]['ansible_host'] }}"
-  when: avalanchego_network_id == 'local'
+    bootstrap_ips: |
+      {{ (bootstrap_ips | default([]))
+         + [hostvars[item]['ansible_host'] + ':' + (avalanchego_staking_port | string)] }}
+  when: avalanchego_network_id not in ['mainnet', 'fuji']
+  loop: "{{ groups['bootstrap_nodes'] }}"
 
 - name: Construct public-ip conf
   set_fact:
@@ -15,11 +18,11 @@
   set_fact:
     node_conf_bootstrap: |
       {{ {
-           'bootstrap-ips': '' if inventory_hostname == groups['bootstrap_node'][0]
-             else (bootstrap_ip + ':' + (avalanchego_staking_port | string)),
-           'bootstrap-ids': '' if inventory_hostname == groups['bootstrap_node'][0]
-             else (avalanchego_bootstrap_node_id) 
-         } if avalanchego_network_id == 'local' else {} }}
+           'bootstrap-ips': '' if inventory_hostname in groups['bootstrap_nodes']
+             else (bootstrap_ips | join(',')),
+           'bootstrap-ids': '' if inventory_hostname in groups['bootstrap_nodes']
+             else (avalanchego_bootstrap_node_ids | join(','))
+         } if avalanchego_network_id not in ['mainnet', 'fuji'] else {} }}
 
 - name: Construct staking-tls-*-file conf
   set_fact:

--- a/roles/node/tasks/install-vms.yml
+++ b/roles/node/tasks/install-vms.yml
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2023, E36 Knots
+---
+- include_tasks: install-vm.yml
+  vars:
+    vm_name: "{{ vm.split('=')[0] }}"
+    vm_version: "{{ vm.split('=')[1] }}"
+    vm_info: "{{ avalanchego_vms_list[vm.split('=')[0]] }}"
+  loop: "{{ avalanchego_vms_install }}"
+  loop_control:
+    loop_var: vm

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -6,42 +6,49 @@
   tags:
     - install
     - avalanchego
+    - install-avalanchego
 
 - name: Clean plugins dir
   import_tasks: clean-plugins-dir.yml
   tags:
     - install
     - vms
+    - install-vms
 
 - name: Install VMs
   import_tasks: install-vms.yml
   tags:
     - install
     - vms
+    - install-vms
 
 - name: Configure AvalancheGo node
   import_tasks: config-node.yml
   tags:
     - config
     - avalanchego
+    - config-avalanchego
 
 - name: Configure subnets
   import_tasks: config-subnets.yml
   tags:
     - config
     - subnets
+    - config-subnets
 
 - name: Configure chains
   import_tasks: config-chains.yml
   tags:
     - config
     - chains
+    - config-chains
 
 - name: Start AvalancheGo node
   import_tasks: start.yml
   tags:
     - start
     - avalanchego
+    - start-avalanchego
 
 - name: Generate Ash CLI local network configuration
   set_fact:
@@ -53,16 +60,33 @@
   tags:
     - install
     - ash_cli
+    - install-ash_cli
   vars:
     ash_cli_local_endpoint: "{{ 'https' if avalanchego_https_enabled else 'http' }}://{{ '127.0.0.1' if avalanchego_http_host == '0.0.0.0' else avalanchego_http_host }}:{{ avalanchego_http_port }}"
-  when: avalanchego_network_id == 'local'
+  when:
+    - ash_cli_install
+    - avalanchego_network_id == 'local'
 
-- name: Install and configure Ash CLI
+- name: Install Ash CLI
   import_role:
     name: ash.avalanche.ash_cli
+    tasks_from: install.yml
   tags:
     - install
     - ash_cli
+    - install-ash_cli
+  vars:
+    ash_cli_avalanche_network_id: "{{ avalanchego_network_id }}"
+  when: ash_cli_install
+
+- name: Configure Ash CLI
+  import_role:
+    name: ash.avalanche.ash_cli
+    tasks_from: config.yml
+  tags:
+    - config
+    - ash_cli
+    - config-ash_cli
   vars:
     ash_cli_avalanche_network_id: "{{ avalanchego_network_id }}"
   when: ash_cli_install

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -2,32 +2,46 @@
 # Copyright (c) 2022-2023, E36 Knots
 ---
 - name: Install AvalancheGo
-  include_tasks: install-avalanchego.yml
+  import_tasks: install-avalanchego.yml
+  tags:
+    - install
+    - avalanchego
 
 - name: Clean plugins dir
-  include_tasks: clean-plugins-dir.yml
+  import_tasks: clean-plugins-dir.yml
+  tags:
+    - install
+    - vms
 
 - name: Install VMs
-  include_tasks: install-vm.yml
-  vars:
-    vm_name: "{{ vm.split('=')[0] }}"
-    vm_version: "{{ vm.split('=')[1] }}"
-    vm_info: "{{ avalanchego_vms_list[vm.split('=')[0]] }}"
-  loop: "{{ avalanchego_vms_install }}"
-  loop_control:
-    loop_var: vm
+  import_tasks: install-vms.yml
+  tags:
+    - install
+    - vms
 
 - name: Configure AvalancheGo node
-  include_tasks: config-node.yml
+  import_tasks: config-node.yml
+  tags:
+    - config
+    - avalanchego
 
 - name: Configure subnets
-  include_tasks: config-subnets.yml
+  import_tasks: config-subnets.yml
+  tags:
+    - config
+    - subnets
 
 - name: Configure chains
-  include_tasks: config-chains.yml
+  import_tasks: config-chains.yml
+  tags:
+    - config
+    - chains
 
 - name: Start AvalancheGo node
-  include_tasks: start.yml
+  import_tasks: start.yml
+  tags:
+    - start
+    - avalanchego
 
 - name: Generate Ash CLI local network configuration
   set_fact:
@@ -36,13 +50,19 @@
         pchain_rpc_url: "{{ ash_cli_local_endpoint }}/ext/bc/P"
         cchain_rpc_url: "{{ ash_cli_local_endpoint }}/ext/bc/C/rpc"
         xchain_rpc_url: "{{ ash_cli_local_endpoint }}/ext/bc/X"
+  tags:
+    - install
+    - ash_cli
   vars:
     ash_cli_local_endpoint: "{{ 'https' if avalanchego_https_enabled else 'http' }}://{{ '127.0.0.1' if avalanchego_http_host == '0.0.0.0' else avalanchego_http_host }}:{{ avalanchego_http_port }}"
   when: avalanchego_network_id == 'local'
 
 - name: Install and configure Ash CLI
-  include_role:
+  import_role:
     name: ash.avalanche.ash_cli
+  tags:
+    - install
+    - ash_cli
   vars:
     ash_cli_avalanche_network_id: "{{ avalanchego_network_id }}"
   when: ash_cli_install


### PR DESCRIPTION
### Linked issues

- Fixes #83 

### Changes

- `avalanche.node`
  - Allow to specify multiple bootstrap nodes on networks other than `mainnet` or `fuji`
  - Use `import_tasks` instead of `include_tasks` in the main playbook. This allows propagating tags to all included tasks.
  - Add tags on all `import_tasks` in the main playbook

### Breaking changes

- `avalanche.node`
  - `bootstrap_node` group renamed to `bootstrap_nodes`
  - `avalanchego_bootstrap_node_id` var renamed to `avalanchego_bootstrap_node_ids`
