### PR TITLE
fix: register ansible's localhost for date command

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -114,12 +114,10 @@ validator_txs_private_key: PrivateKey-ewoqjP7PxY4yr3iLTpLisriqt94hdyDFNgchSxGGzt
 validator_txs_key_encoding: cb58
 
 ## Validation parameters
-validator_start_time_command_default: 'date -d "2 minutes" --rfc-3339=seconds | tr " " T' # in 2 minutes
-validator_end_time_command_default: 'date -d "1 week 2 minutes" --rfc-3339=seconds | tr " " T' # in 1 week and 2 minutes
-validator_start_time_command_darwin: "date -v+2M '+%Y-%m-%dT%H:%M:%SZ'" # in 2 minutes
-validator_end_time_command_darwin: "date -v+1w -v+2M '+%Y-%m-%dT%H:%M:%SZ'" # in 1 week and 2 minutes
-validator_start_time: '{{ lookup("pipe", lookup("vars", "validator_start_time_command_"+ansible_os_family | lower, default=validator_start_time_command_default)) }}'
-validator_end_time: '{{ lookup("pipe", lookup("vars", "validator_end_time_command_"+ansible_os_family | lower, default=validator_end_time_command_default)) }}'
+validator_start_time_command: 'date -d "2 minutes" --rfc-3339=seconds | tr " " T' # in 2 minutes
+validator_start_time: "{{ validator_start_time_command_output }}"
+validator_end_time_command: 'date -d "1 week 2 minutes" --rfc-3339=seconds | tr " " T' # in 1 week and 2 minutes
+validator_end_time: "{{ validator_end_time_command_output }}"
 ### Stake in AVAX for the Primary Network or weight for permissioned Subnets
 validator_stake_or_weight: 1
 ### In percent. Only used for the Primary Network

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -115,9 +115,11 @@ validator_txs_key_encoding: cb58
 
 ## Validation parameters
 validator_start_time_command: 'date -d "2 minutes" --rfc-3339=seconds | tr " " T' # in 2 minutes
-validator_start_time: "{{ validator_start_time_command_output }}"
 validator_end_time_command: 'date -d "1 week 2 minutes" --rfc-3339=seconds | tr " " T' # in 1 week and 2 minutes
-validator_end_time: "{{ validator_end_time_command_output }}"
+### Either a timestamp in RFC 3339 format or 'start_time_command_output' that will be resolved
+validator_start_time: start_time_command_output
+### Either a timestamp in RFC 3339 format or 'end_time_command_output' that will be resolved
+validator_end_time: end_time_command_output
 ### Stake in AVAX for the Primary Network or weight for permissioned Subnets
 validator_stake_or_weight: 1
 ### In percent. Only used for the Primary Network

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -18,26 +18,6 @@
       https: "{{ avalanchego_https_enabled }}"
   register: node_info_res
 
-- name: Resolve validator_start_time_command if validator_start_time is undefined
-  shell: "{{ validator_start_time_command }}"
-  register: validator_start_time_res
-  when: validator_start_time is undefined
-
-- name: Set validator_start_time_command_output to the result of validator_start_time_command
-  set_fact:
-    validator_start_time_command_output: "{{ validator_start_time_res.stdout }}"
-  when: validator_start_time is undefined
-
-- name: Resolve validator_end_time_command if validator_end_time is undefined
-  shell: "{{ validator_end_time_command }}"
-  register: validator_end_time_res
-  when: validator_end_time is undefined
-
-- name: Set validator_end_time_command_output to the result of validator_end_time_command
-  set_fact:
-    validator_end_time_command_output: "{{ validator_end_time_res.stdout }}"
-  when: validator_end_time is undefined
-
 - name: Add the node as validator
   include_role:
     name: ash.avalanche.subnet
@@ -47,7 +27,9 @@
     node_id: "{{ node_info_res.output.id }}"
     subnet_txs_private_key: "{{ validator_txs_private_key }}"
     subnet_txs_key_encoding: "{{ validator_txs_key_encoding }}"
+    start_time_command: "{{ validator_start_time_command }}"
     start_time: "{{ validator_start_time }}"
+    end_time_command: "{{ validator_end_time_command }}"
     end_time: "{{ validator_end_time }}"
     stake_or_weight: "{{ validator_stake_or_weight }}"
     delegation_fee: "{{ validator_delegation_fee }}"

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -18,6 +18,26 @@
       https: "{{ avalanchego_https_enabled }}"
   register: node_info_res
 
+- name: Resolve validator_start_time_command if validator_start_time is undefined
+  shell: "{{ validator_start_time_command }}"
+  register: validator_start_time_res
+  when: validator_start_time is undefined
+
+- name: Set validator_start_time_command_output to the result of validator_start_time_command
+  set_fact:
+    validator_start_time_command_output: "{{ validator_start_time_res.stdout }}"
+  when: validator_start_time is undefined
+
+- name: Resolve validator_end_time_command if validator_end_time is undefined
+  shell: "{{ validator_end_time_command }}"
+  register: validator_end_time_res
+  when: validator_end_time is undefined
+
+- name: Set validator_end_time_command_output to the result of validator_end_time_command
+  set_fact:
+    validator_end_time_command_output: "{{ validator_end_time_res.stdout }}"
+  when: validator_end_time is undefined
+
 - name: Add the node as validator
   include_role:
     name: ash.avalanche.subnet

--- a/roles/subnet/defaults/main.yml
+++ b/roles/subnet/defaults/main.yml
@@ -69,12 +69,12 @@ subnet_validators_params:
   ##     delegation_fee: 2
 
 ## Default validation parameters
-subnet_validator_start_time_command_default: 'date -d "2 minutes" --rfc-3339=seconds | tr " " T' # in 2 minutes
-subnet_validator_end_time_command_default: 'date -d "1 week 2 minutes" --rfc-3339=seconds | tr " " T' # in 1 week and 2 minutes
-subnet_validator_start_time_command_darwin: "date -v+2M '+%Y-%m-%dT%H:%M:%SZ'" # in 2 minutes
-subnet_validator_end_time_command_darwin: "date -v+1w -v+2M '+%Y-%m-%dT%H:%M:%SZ'" # in 1 week and 2 minutes
-subnet_validator_start_time: '{{ lookup("pipe", lookup("vars", "subnet_validator_start_time_command_"+ansible_os_family | lower, default=subnet_validator_start_time_command_default)) }}'
-subnet_validator_end_time: '{{ lookup("pipe", lookup("vars", "subnet_validator_end_time_command_"+ansible_os_family | lower, default=subnet_validator_end_time_command_default)) }}'
+subnet_validator_start_time_command: 'date -d "2 minutes" --rfc-3339=seconds | tr " " T' # in 2 minutes
+subnet_validator_end_time_command: 'date -d "1 week 2 minutes" --rfc-3339=seconds | tr " " T' # in 1 week and 2 minutes
+### Either a timestamp in RFC 3339 format or 'start_time_command_output' that will be resolved
+subnet_validator_start_time: start_time_command_output
+### Either a timestamp in RFC 3339 format or 'end_time_command_output' that will be resolved
+subnet_validator_end_time: end_time_command_output
 ### Stake in AVAX for the Primary Network or weight for permissioned Subnets
 subnet_validator_stake_or_weight: 100
 ### In percent. Only used for the Primary Network

--- a/roles/subnet/tasks/add-validator.yml
+++ b/roles/subnet/tasks/add-validator.yml
@@ -5,10 +5,30 @@
 # Parameters
 # - subnet_id: ID of the Subnet to add the validator to
 # - node_id: ID of the node to add as validator
-# - start_time: Start time of the validation period
-# - end_time: End time of the validation period
+# - start_time_command: Command to generate the start time of the validation period
+# - start_time: Start time of the validation period. Will be resolved if set to 'start_time_command_output'
+# - end_time_command: Command to generate the end time of the validation period
+# - end_time: End time of the validation period. Will be resolved if set to 'end_time_command_output'
 # - stake_or_weight: Stake in AVAX or weight of the validator
 # - delegation_fee: Delegation fee of the validator
+
+- name: Resolve start_time_command
+  shell: "{{ start_time_command | default(subnet_validator_start_time_command) }}"
+  register: start_time_res
+  changed_when: false
+
+- name: Set start_time_command_output
+  set_fact:
+    start_time_command_output: "{{ start_time_res.stdout }}"
+
+- name: Resolve end_time_command
+  shell: "{{ end_time_command | default(subnet_validator_end_time_command) }}"
+  register: end_time_res
+  changed_when: false
+
+- name: Set end_time_command_output
+  set_fact:
+    end_time_command_output: "{{ end_time_res.stdout }}"
 
 - name: Check if the node is already a validator (1/2)
   ash.avalanche.ash_cmd:
@@ -42,8 +62,8 @@
     command: "avalanche validator add {{ node_id }} {{ stake_or_weight }}"
     options:
       subnet-id: "{{ subnet_id }}"
-      start-time: "{{ start_time }}"
-      end-time: "{{ end_time }}"
+      start-time: "{{ start_time if start_time != 'start_time_command_output' else start_time_command_output }}"
+      end-time: "{{ end_time if end_time != 'end_time_command_output' else end_time_command_output }}"
       delegation-fee: "{{ delegation_fee }}"
     avalanche_private_key: "{{ subnet_txs_private_key }}"
   environment:


### PR DESCRIPTION
### Linked issues

- Fix #92 

### Breaking Changes

- Introduced `validator_command_os_family` with default value `Debian`
- Removed `subnet_validator_*_time_*` vars and replaced with hardcoded timestamps in the example. Makes more sense IMO since it's there to showcase how to define specific weight, times, etc. for each nodes. Will update the docs accordingly if you agree.