### PR TITLE
fix: VM binary arch

### DIFF
--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -23,8 +23,8 @@
   set_fact:
     node_conf_staking_tls_files: |
       {{ {
-           'staking-tls-cert-file': avalanchego_staking_certs_dir + '/' + inventory_hostname + '.crt',
-           'staking-tls-key-file': avalanchego_staking_certs_dir + '/' + inventory_hostname + '.key'
+           'staking-tls-cert-file': avalanchego_staking_certs_dir + '/node.crt',
+           'staking-tls-key-file': avalanchego_staking_certs_dir + '/node.key'
          } if avalanchego_staking_use_local_certs else {} }}
 
 - name: Construct http-tls-*-file conf
@@ -55,7 +55,7 @@
 - name: Upload node staking certificates
   copy:
     src: "{{ avalanchego_staking_local_certs_dir }}/{{ inventory_hostname }}.{{ item }}"
-    dest: "{{ avalanchego_staking_certs_dir }}/{{ inventory_hostname }}.{{ item }}"
+    dest: "{{ avalanchego_staking_certs_dir }}/node.{{ item }}"
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"
     mode: 0400

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
+- name: Set avalanchego_vm_binary_arch according to ansible_architecture
+  set_fact:
+    avalanchego_vm_binary_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else avalanchego_vm_binary_arch }}"
+
 - name: "Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}"
   debug:
     msg: "AvalancheGo version {{ item.key }} {{ item.value }}: {{ avalanchego_version is version(item.value, item.key) }}"

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -25,7 +25,8 @@ avalanchego_vms_conf_dir: "{{ avalanchego_conf_dir }}/vms"
 avalanchego_http_protocol: "{{ 'https' if avalanchego_https_enabled else 'http' }}"
 
 # String templates for VM files to download
-avalanchego_vm_binary_filename: "{{ vm_name }}_{{ vm_version }}_linux_amd64.tar.gz"
+avalanchego_vm_binary_arch: amd64
+avalanchego_vm_binary_filename: "{{ vm_name }}_{{ vm_version }}_linux_{{ avalanchego_vm_binary_arch }}.tar.gz"
 avalanchego_vm_checksum_filename: "{{ vm_name }}_{{ vm_version }}_checksums.txt"
 
 # Avalanche constants


### PR DESCRIPTION
### Linked issues

- Fixes #98 
- Fixes #100 

### Changes

- `ash.avalanche.node`
  - Download the VM binary based on the host arch
  - Upload staking TLS cert + key as `node.(cert|key)`
