### PR TITLE
feat(node): create a parent directory in /var/lib

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -9,7 +9,7 @@ avalanchego_install_dir: /opt/avalanche/avalanchego
 avalanchego_vms_dir: /opt/avalanche/vms
 
 # DB directory
-avalanchego_db_dir: /var/lib/avalanchego/db
+avalanchego_db_dir: /var/lib/avalanche/avalanchego/db
 
 # Configuration directories
 avalanchego_conf_dir: /etc/avalanche/avalanchego/conf


### PR DESCRIPTION
### Breaking Changes

- Create the `avalanche` parent directory in `/var/lib` to enable storing data from other Avalanche software