### PR TITLE
fix(node): add 'testnet' as a public networks

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -52,7 +52,7 @@ avalanchego_staking_local_certs_dir: "{{ playbook_dir }}/files/staking"
 
 # Bootstrapping
 avalanchego_network_id: fuji
-## Node IDs of the bootstrap nodes on networks other than `mainnet` and `fuji`
+## Node IDs of the bootstrap nodes on networks other than `mainnet`, `testnet` and `fuji`
 avalanchego_bootstrap_node_ids:
   - NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
 avalanchego_bootstrap_db: ""

--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -6,7 +6,7 @@
     bootstrap_ips: |
       {{ (bootstrap_ips | default([]))
          + [hostvars[item]['ansible_host'] + ':' + (avalanchego_staking_port | string)] }}
-  when: avalanchego_network_id not in ['mainnet', 'fuji']
+  when: avalanchego_network_id not in ['mainnet', 'testnet', 'fuji']
   loop: "{{ groups['bootstrap_nodes'] }}"
 
 - name: Construct bootstrap-* conf
@@ -17,7 +17,7 @@
              else (bootstrap_ips | join(',')),
            'bootstrap-ids': '' if inventory_hostname in groups['bootstrap_nodes']
              else (avalanchego_bootstrap_node_ids | join(','))
-         } if avalanchego_network_id not in ['mainnet', 'fuji'] else {} }}
+         } if avalanchego_network_id not in ['mainnet', 'testnet', 'fuji'] else {} }}
 
 - name: Construct staking-tls-*-file conf
   set_fact:


### PR DESCRIPTION
### Changes

- Add `testnet` as a known public network (where bootstrap nodes are not needed). See [Network ID](https://docs.avax.network/nodes/configure/avalanchego-config-flags#network-id)