### PR TITLE
fix(node): default value for ash_cli_networks

### DIFF
--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -96,5 +96,5 @@
     - config-ash_cli
   vars:
     ash_cli_avalanche_network_id: "{{ avalanchego_network_id }}"
-    ash_cli_custom_networks: "{{ ash_cli_networks }}"
+    ash_cli_custom_networks: "{{ ash_cli_networks | default({}) }}"
   when: ash_cli_install


### PR DESCRIPTION
### Linked issues

- Fixes #104 

### Changes

- Add a default value for `ash_cli_networks` (useful for networks other than `local`)