### PR TITLE
feat(node): use VM ID for symlinks to VM binary

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -87,7 +87,6 @@ avalanchego_node_json:
   subnet-config-dir: "{{ avalanchego_subnets_conf_dir }}"
   chain-config-dir: "{{ avalanchego_chains_conf_dir }}"
   chain-aliases-file: "{{ avalanchego_chains_conf_dir }}/aliases.json"
-  vm-aliases-file: "{{ avalanchego_vms_conf_dir }}/aliases.json"
   log-dir: "{{ avalanchego_log_dir }}"
   # Logging
   log-level: info

--- a/roles/node/tasks/clean-plugins-dir.yml
+++ b/roles/node/tasks/clean-plugins-dir.yml
@@ -1,16 +1,22 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2023, E36 Knots
 ---
-- name: List links in {{ avalanchego_plugins_dir }}
+- name: "Get symlinks in {{ avalanchego_plugins_dir }}"
   find:
     paths: "{{ avalanchego_plugins_dir }}"
     file_type: link
   register: links
 
+- name: Set expected_plugins variable
+  set_fact:
+    expected_plugins: "{{ expected_plugins | default([]) + [avalanchego_vms_list[item].id] }}"
+  loop: "{{ avalanchego_vms_install | map('regex_replace', '=.*$', '') }}"
+
 - name: "Remove outdated links in {{ avalanchego_plugins_dir }}"
   file:
     path: "{{ item.path }}"
     state: absent
-  when: (item.path | basename) not in (avalanchego_vms_install | join)
-  no_log: true
-  with_items: "{{ links.files }}"
+  when: (item.path | basename) not in expected_plugins
+  loop: "{{ links.files }}"
+  loop_control:
+    label: "{{ item.path }}"

--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -104,12 +104,3 @@
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"
   notify: Restart avalanchego
-
-- name: Template VM aliases.json file
-  template:
-    src: vm-aliases.json.j2
-    dest: "{{ avalanchego_vms_conf_dir }}/aliases.json"
-    lstrip_blocks: true
-    owner: "{{ avalanchego_user }}"
-    group: "{{ avalanchego_group }}"
-  notify: New VM

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -41,12 +41,12 @@
     remote_src: true
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"
-    creates: "{{ avalanchego_vms_dir }}/{{ vm_name}}/{{ vm_name }}-v{{ vm_version }}/{{ vm_name }}"
+    creates: "{{ avalanchego_vms_dir }}/{{ vm_name}}/{{ vm_name }}-v{{ vm_version }}/{{ vm_info.binary_filename }}"
 
 - name: "Create the symlink to {{ vm_name }} binary in plugins dir"
   file:
-    src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/{{ vm_name }}-v{{ vm_version }}/{{ vm_name }}"
-    dest: "{{ avalanchego_plugins_dir }}/{{ vm_name }}"
+    src: "{{ avalanchego_vms_dir }}/{{ vm_name }}/{{ vm_name }}-v{{ vm_version }}/{{ vm_info.binary_filename }}"
+    dest: "{{ avalanchego_plugins_dir }}/{{ vm_info.id }}"
     state: link
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -26,8 +26,8 @@ avalanchego_http_protocol: "{{ 'https' if avalanchego_https_enabled else 'http' 
 
 # String templates for VM files to download
 avalanchego_vm_binary_arch: amd64
-avalanchego_vm_binary_filename: "{{ vm_name }}_{{ vm_version }}_linux_{{ avalanchego_vm_binary_arch }}.tar.gz"
-avalanchego_vm_checksum_filename: "{{ vm_name }}_{{ vm_version }}_checksums.txt"
+avalanchego_vm_binary_filename: "{{ vm_info.binary_filename }}_{{ vm_version }}_linux_{{ avalanchego_vm_binary_arch }}.tar.gz"
+avalanchego_vm_checksum_filename: "{{ vm_info.binary_filename }}_{{ vm_version }}_checksums.txt"
 
 # Avalanche constants
 avalanche_primary_network_id: 11111111111111111111111111111111LpoYY
@@ -39,8 +39,8 @@ avalanchego_vms_list:
     id: srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy
     # Used in Ash CLI
     ash_vm_type: SubnetEVM
-    aliases:
-      - subnet-evm
+    # The VM binary filename
+    binary_filename: subnet-evm
     versions_comp:
       # Protocol version: 22
       0.4.8:


### PR DESCRIPTION
### Linked issues

- Fixes #106 

### Breaking changes

- `avalanche.node` role
  - Remove the usage of VM aliases and use the VM ID as the name for the symlink to the VM binary
  - Decorrelate the VM name (in the collection conf) and the binary filename (to be downloaded + extracted). This allows installing the same VM multiple times with different VM IDs.

### Additional comments

You can test this by installing the Subnet EVM with the default ID + the Subnet VM with a different ID and creating a Subnet using the 2 VMs for 2 blockchains.

In `ansible-avalanche-getting-started`:
```yaml
# inventory/local/group_vars/avalanche_node.yml
avalanchego_vms_list:
  dexalot-subnet-evm:
    download_url: https://github.com/ava-labs/subnet-evm/releases/download
    id: mDVSxzeWHpEU3eSqMwwGQsD787xGp7hv9Qgoe3R9SdjPapte8
    # Used in Ash CLI
    ash_vm_type: SubnetEVM
    # The binary filename to look for in the archive
    binary_filename: subnet-evm
    versions_comp:
      # Protocol version: 30
      0.5.9:
        ge: 1.10.15
        le: 1.10.17
      0.5.10:
        ge: 1.10.15
        le: 1.10.17

avalanchego_vms_install:
  - subnet-evm=0.5.10
  - dexalot-subnet-evm=0.5.10
```
```yaml
# inventory/local/group_vars/subnet_txs_host.yml
subnet_blockchains_list:
  - name: AshLocalEVM
    vm: subnet-evm
    genesis_data:
      config:
        chainId: 66666
        homesteadBlock: 0
        eip150Block: 0
        eip150Hash: "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"
        eip155Block: 0
        eip158Block: 0
        byzantiumBlock: 0
        constantinopleBlock: 0
        petersburgBlock: 0
        istanbulBlock: 0
        muirGlacierBlock: 0
        subnetEVMTimestamp: 0
        feeConfig:
          gasLimit: 8000000
          minBaseFee: 25000000000
          targetGas: 15000000
          baseFeeChangeDenominator: 36
          minBlockGasCost: 0
          maxBlockGasCost: 1000000
          targetBlockRate: 2
          blockGasCostStep: 200000
      alloc:
        8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC:
          balance: "0x295BE96E64066972000000"
      nonce: "0x0"
      timestamp: "0x0"
      extraData: "0x00"
      gasLimit: "0x7A1200"
      difficulty: "0x0"
      mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
      coinbase: "0x0000000000000000000000000000000000000000"
      number: "0x0"
      gasUsed: "0x0"
      parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
  - name: DexalotLocalEVM
    vm: dexalot-subnet-evm
    genesis_data:
      config:
        chainId: 66667
        homesteadBlock: 0
        eip150Block: 0
        eip150Hash: "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"
        eip155Block: 0
        eip158Block: 0
        byzantiumBlock: 0
        constantinopleBlock: 0
        petersburgBlock: 0
        istanbulBlock: 0
        muirGlacierBlock: 0
        subnetEVMTimestamp: 0
        feeConfig:
          gasLimit: 8000000
          minBaseFee: 25000000000
          targetGas: 15000000
          baseFeeChangeDenominator: 36
          minBlockGasCost: 0
          maxBlockGasCost: 1000000
          targetBlockRate: 2
          blockGasCostStep: 200000
      alloc:
        8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC:
          balance: "0x295BE96E64066972000000"
      nonce: "0x0"
      timestamp: "0x0"
      extraData: "0x00"
      gasLimit: "0x7A1200"
      difficulty: "0x0"
      mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
      coinbase: "0x0000000000000000000000000000000000000000"
      number: "0x0"
      gasUsed: "0x0"
      parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000"

```
The 2 blockchains both use the Subnet EVM under different VM IDs.