### PR TITLE
feat: comment subnet_blockchains_list

### DIFF
--- a/roles/subnet/defaults/main.yml
+++ b/roles/subnet/defaults/main.yml
@@ -13,46 +13,48 @@ subnet_txs_key_encoding: cb58
 subnet_blockchains_check_name: true
 ## List of blockchains to create in the Subnet
 subnet_blockchains_list:
-  - name: AshSubnetEVM
-    ## Name of the VM in the collection
-    ## See https://ash.center/docs/toolkit/ansible-avalanche-collection/reference/roles/avalanche-node#supported-vms-and-avalanchego-compatibility
-    vm: subnet-evm
-    genesis_data:
-      config:
-        chainId: 66666
-        homesteadBlock: 0
-        eip150Block: 0
-        eip150Hash: "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"
-        eip155Block: 0
-        eip158Block: 0
-        byzantiumBlock: 0
-        constantinopleBlock: 0
-        petersburgBlock: 0
-        istanbulBlock: 0
-        muirGlacierBlock: 0
-        subnetEVMTimestamp: 0
-        feeConfig:
-          gasLimit: 8000000
-          minBaseFee: 25000000000
-          targetGas: 15000000
-          baseFeeChangeDenominator: 36
-          minBlockGasCost: 0
-          maxBlockGasCost: 1000000
-          targetBlockRate: 2
-          blockGasCostStep: 200000
-      alloc:
-        8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC:
-          balance: "0x295BE96E64066972000000"
-      nonce: "0x0"
-      timestamp: "0x0"
-      extraData: "0x00"
-      gasLimit: "0x7A1200"
-      difficulty: "0x0"
-      mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
-      coinbase: "0x0000000000000000000000000000000000000000"
-      number: "0x0"
-      gasUsed: "0x0"
-      parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+  []
+  ## Example:
+  ## - name: AshSubnetEVM
+  ##   ## Name of the VM in the collection
+  ##   ## See https://ash.center/docs/toolkit/ansible-avalanche-collection/reference/roles/avalanche-node#supported-vms-and-avalanchego-compatibility
+  ##   vm: subnet-evm
+  ##   genesis_data:
+  ##     config:
+  ##       chainId: 66666
+  ##       homesteadBlock: 0
+  ##       eip150Block: 0
+  ##       eip150Hash: "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0"
+  ##       eip155Block: 0
+  ##       eip158Block: 0
+  ##       byzantiumBlock: 0
+  ##       constantinopleBlock: 0
+  ##       petersburgBlock: 0
+  ##       istanbulBlock: 0
+  ##       muirGlacierBlock: 0
+  ##       subnetEVMTimestamp: 0
+  ##       feeConfig:
+  ##         gasLimit: 8000000
+  ##         minBaseFee: 25000000000
+  ##         targetGas: 15000000
+  ##         baseFeeChangeDenominator: 36
+  ##         minBlockGasCost: 0
+  ##         maxBlockGasCost: 1000000
+  ##         targetBlockRate: 2
+  ##         blockGasCostStep: 200000
+  ##     alloc:
+  ##       8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC:
+  ##         balance: "0x295BE96E64066972000000"
+  ##     nonce: "0x0"
+  ##     timestamp: "0x0"
+  ##     extraData: "0x00"
+  ##     gasLimit: "0x7A1200"
+  ##     difficulty: "0x0"
+  ##     mixHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
+  ##     coinbase: "0x0000000000000000000000000000000000000000"
+  ##     number: "0x0"
+  ##     gasUsed: "0x0"
+  ##     parentHash: "0x0000000000000000000000000000000000000000000000000000000000000000"
 
 # Validators configuration
 ## Whether to add validator nodes to the Subnet


### PR DESCRIPTION
### Linked issues

- Fix #111 

### Changes

- Comment `subnet_blockchains_list` to make it an example

### Additional comments

- We should be fine since we already define `subnet_blockchains_list` in the `ansible-avalanche-getting-started` inventory
