### PR TITLE
feat(node): use a dict for avalanchego_vms_install

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -61,11 +61,11 @@ avalanchego_bootstrap_db: ""
 avalanchego_track_subnets: []
 
 # VMs
-avalanchego_vms_install: []
+avalanchego_vms_install: {}
 ## Example
-##  - subnet-evm=0.4.10
-##  - timestampvm=1.3.0
-##  - spacesvm=0.0.15
+##  subnet-evm: 0.4.10
+##  timestampvm: 1.3.0
+##  spacesvm: 0.0.15
 
 # node.json
 avalanchego_node_json:
@@ -102,11 +102,12 @@ avalanchego_chains_aliases:
   ## Example:
   ##   q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi:
   ##     - DFK
+
 avalanchego_chains_configs:
   C:
     state-sync-enabled: true
 
-# Chains updates
+# Chains upgrades
 avalanchego_chains_upgrades:
   {}
   ## Example:

--- a/roles/node/tasks/clean-plugins-dir.yml
+++ b/roles/node/tasks/clean-plugins-dir.yml
@@ -10,7 +10,7 @@
 - name: Set expected_plugins variable
   set_fact:
     expected_plugins: "{{ expected_plugins | default([]) + [avalanchego_vms_list[item].id] }}"
-  loop: "{{ avalanchego_vms_install | map('regex_replace', '=.*$', '') }}"
+  loop: "{{ avalanchego_vms_install.keys() }}"
 
 - name: "Remove outdated links in {{ avalanchego_plugins_dir }}"
   file:

--- a/roles/node/tasks/install-vms.yml
+++ b/roles/node/tasks/install-vms.yml
@@ -4,9 +4,9 @@
 - name: Install VMs
   include_tasks: install-vm.yml
   vars:
-    vm_name: "{{ vm.split('=')[0] }}"
-    vm_version: "{{ vm.split('=')[1] }}"
-    vm_info: "{{ avalanchego_vms_list[vm.split('=')[0]] }}"
-  loop: "{{ avalanchego_vms_install }}"
+    vm_name: "{{ vm.key }}"
+    vm_version: "{{ vm.value }}"
+    vm_info: "{{ avalanchego_vms_list[vm.key] }}"
+  loop: "{{ avalanchego_vms_install | dict2items }}"
   loop_control:
     loop_var: vm

--- a/roles/node/templates/vm-aliases.json.j2
+++ b/roles/node/templates/vm-aliases.json.j2
@@ -1,8 +1,0 @@
-{# SPDX-License-Identifier: BSD-3-Clause
-Copyright (c) 2022-2023, E36 Knots #}
-{
-  {% for vm in avalanchego_vms_install %}
-  {% set vm_name = vm.split('=')[0] %}
-  "{{ avalanchego_vms_list[vm_name].id }}": {{ avalanchego_vms_list[vm_name].aliases | to_json }}{{ ',' if not loop.last else '' }}
-  {% endfor %}
-}


### PR DESCRIPTION
### Linked issues

- Fixes #113 

### Breaking changes

- `avalanche.node`
  - Change `avalanchego_vms_install` to a dictionary to ease merging multi-file configurations.

### Additional comments

To migrate, one has to change the list of VMs to install. E.g.
```yaml
# Current variable
avalanchego_vms_install:
  - subnet-evm=0.5.10

# New variable
avalanchego_vms_install:
  subnet-evm: 0.5.10
```
