### PR TITLE
fix to allow different network ids between ash_cli and avalanchego

### DIFF
--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -142,3 +142,5 @@ validator_delegation_fee: 2
 # Ash CLI configuration
 ## Whether to install and configure Ash CLI on the node
 ash_cli_install: true
+## The avalanche network name to be used in ash_cmd
+ash_cli_network_id: fuji

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -142,5 +142,5 @@ validator_delegation_fee: 2
 # Ash CLI configuration
 ## Whether to install and configure Ash CLI on the node
 ash_cli_install: true
-## The avalanche network name to be used in ash_cmd
+## The avalanche network to be used in the Ash CLI (sets the RPC endpoints to use)
 ash_cli_network_id: fuji

--- a/roles/node/tasks/health-checks.yml
+++ b/roles/node/tasks/health-checks.yml
@@ -29,7 +29,7 @@
       ash_cmd:
         command: "avalanche subnet info {{ item }}"
       environment:
-        AVALANCHE_NETWORK: "{{ avalanchego_network_id }}"
+        AVALANCHE_NETWORK: "{{ ash_cli_network_id }}"
       register: tracked_subnets_info_res
       loop: "{{ [avalanche_primary_network_id] + avalanchego_track_subnets }}"
       until:
@@ -49,7 +49,7 @@
           http-port: "{{ avalanchego_http_port }}"
           https: "{{ avalanchego_https_enabled }}"
       environment:
-        AVALANCHE_NETWORK: "{{ avalanchego_network_id }}"
+        AVALANCHE_NETWORK: "{{ ash_cli_network_id }}"
       register: avalanchego_is_bootstrapped_res
       loop: "{{ tracked_chains_ids }}"
       until: avalanchego_is_bootstrapped_res is succeeded

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -95,6 +95,6 @@
     - ash_cli
     - config-ash_cli
   vars:
-    ash_cli_avalanche_network_id: "{{ avalanchego_network_id }}"
+    ash_cli_avalanche_network_id: "{{ ash_cli_network_id }}"
     ash_cli_custom_networks: "{{ ash_cli_networks | default({}) }}"
   when: ash_cli_install


### PR DESCRIPTION
### Linked issues

- Fixes #115 

### Dependencies

None

### Changes

This PR adds a new variable ash_cli_network_id to the node defaults/main.yml and uses it in health_checks and main tasks of the node role.  It allows the ash_cli and avalanchego to have different network ids.

### Breaking changes

None

### Additional comments

None
