### PR TITLE
feat(node): support BLS staking key + custom network genesis

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022-2023, E36 Knots
+Copyright (c) 2022-2024, E36 Knots
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 
 ### REQUIRED
 # The namespace of the collection. This can be a company/brand/organization or product namespace under which all

--- a/playbooks/add_network_validators.yml
+++ b/playbooks/add_network_validators.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Add nodes as network validators (on the Primary Network)
 - name: Add network validators

--- a/playbooks/add_subnet_validators.yml
+++ b/playbooks/add_subnet_validators.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Add nodes as Subnet validators (to `add_validators_subnet_id` Subnet)
 - name: Add Subnet validators

--- a/playbooks/bootstrap_local_network.yml
+++ b/playbooks/bootstrap_local_network.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Provision bootstrap nodes
   hosts: bootstrap_nodes

--- a/playbooks/create_blockchain.yml
+++ b/playbooks/create_blockchain.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # This playbook is provided as an example of how to create a blockchain in an existing subnet.
 # The create_subnet.yml playbook is the recommended way to create a subnet and its blockchains.

--- a/playbooks/create_subnet.yml
+++ b/playbooks/create_subnet.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Create a Subnet and add nodes from the `subnet_validators` group as validators
 - name: Create the Subnet

--- a/playbooks/health_checks.yml
+++ b/playbooks/health_checks.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Run health checks on the nodes
   hosts: avalanche_nodes

--- a/playbooks/install_blockscout_docker.yml
+++ b/playbooks/install_blockscout_docker.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install Blockscout
   hosts: blockscout

--- a/playbooks/install_faucet_docker.yml
+++ b/playbooks/install_faucet_docker.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install Avalanche Faucet
   hosts: faucet

--- a/playbooks/install_monitoring_stack.yml
+++ b/playbooks/install_monitoring_stack.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install Prometheus Node Exporter
   hosts: avalanche_nodes

--- a/playbooks/provision_nodes.yml
+++ b/playbooks/provision_nodes.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Provision nodes
   hosts: avalanche_nodes

--- a/playbooks/rolling_restart.yml
+++ b/playbooks/rolling_restart.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Rolling restart nodes
   hosts: avalanche_nodes

--- a/plugins/filter/convert.py
+++ b/plugins/filter/convert.py
@@ -1,21 +1,21 @@
 #!/usr/bin/python
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 
 from ansible.errors import AnsibleError
 
 
 class FilterModule(object):
     def filters(self):
-        return {'convert': self.convert}
+        return {"convert": self.convert}
 
     def convert(self, amount, from_unit, to_unit):
         units = {
-            'wei': 1,
-            'gwei': 1e9,
-            'navax': 1e9,
-            'avax': 1e18,
-            'eth': 1e18,
+            "wei": 1,
+            "gwei": 1e9,
+            "navax": 1e9,
+            "avax": 1e18,
+            "eth": 1e18,
         }
 
         from_unit_lower = from_unit.lower()

--- a/plugins/filter/crypto.py
+++ b/plugins/filter/crypto.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 
 from ansible.errors import AnsibleError
 
@@ -11,10 +11,10 @@ from web3 import Web3
 class FilterModule(object):
     def filters(self):
         return {
-            'cb58_to_hex': self.cb58_to_hex,
-            'cb58_to_bytes': self.cb58_to_bytes,
-            'hex_to_cb58': self.hex_to_cb58,
-            'hex_to_bytes': self.hex_to_bytes,
+            "cb58_to_hex": self.cb58_to_hex,
+            "cb58_to_bytes": self.cb58_to_bytes,
+            "hex_to_cb58": self.hex_to_cb58,
+            "hex_to_bytes": self.hex_to_bytes,
         }
 
     def cb58_to_hex(self, string):

--- a/plugins/modules/ash_cmd.py
+++ b/plugins/modules/ash_cmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 
 from __future__ import absolute_import, division, print_function
 
@@ -140,7 +140,7 @@ def run_module():
 
     # If the command triggered a transaction, then set changed to true
     if transaction:
-        result['changed'] = True
+        result["changed"] = True
 
     # Save the command that was executed
     result["command"] = " ".join(command)

--- a/plugins/modules/eth_call.py
+++ b/plugins/modules/eth_call.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 
 from __future__ import absolute_import, division, print_function
 from ansible.module_utils.basic import AnsibleModule
@@ -16,67 +16,67 @@ __metaclass__ = type
 
 # Cast bytes and int parameters to make sure they are in the right format
 def cast_parameters(result):
-    param_types = re.match(r'.+\((.+)\)', result['function_sig']).group(1).split(',')
+    param_types = re.match(r".+\((.+)\)", result["function_sig"]).group(1).split(",")
 
-    if len(param_types) != len(result['parameters']):
-        result['msg'] = (
-            'The number of parameters does not match function signature. '
+    if len(param_types) != len(result["parameters"]):
+        result["msg"] = (
+            "The number of parameters does not match function signature. "
             f'Expected {len(param_types)}, got {len(result["parameters"])}'
         )
-        result['failed'] = True
+        result["failed"] = True
         return
 
     casted_params = []
 
-    for i, p in enumerate(result['parameters']):
-        if 'bytes' in param_types[i]:
+    for i, p in enumerate(result["parameters"]):
+        if "bytes" in param_types[i]:
             casted_params.append(HexBytes(p))
-        elif 'int' in param_types[i]:
+        elif "int" in param_types[i]:
             casted_params.append(int(p))
         else:
             casted_params.append(p)
 
-    result['casted_params'] = casted_params
+    result["casted_params"] = casted_params
 
 
 def eth_call(result):
-    c_chain = Web3(Web3.HTTPProvider(result['rpc_url']))
+    c_chain = Web3(Web3.HTTPProvider(result["rpc_url"]))
 
     ash_router = c_chain.eth.contract(
-        address=result['contract_addr'], abi=result['abi']
+        address=result["contract_addr"], abi=result["abi"]
     )
 
-    result['call_return'] = ash_router.get_function_by_signature(
-        result['function_sig']
-    )(*result['casted_params']).call()
+    result["call_return"] = ash_router.get_function_by_signature(
+        result["function_sig"]
+    )(*result["casted_params"]).call()
 
 
 def main():
     module_args = dict(
-        rpc_url=dict(type='str', required=True),
-        contract_addr=dict(type='str', required=True),
-        abi=dict(type='raw', required=True),
-        function_sig=dict(type='str', required=True),
-        parameters=dict(type='raw', required=True),
+        rpc_url=dict(type="str", required=True),
+        contract_addr=dict(type="str", required=True),
+        abi=dict(type="raw", required=True),
+        function_sig=dict(type="str", required=True),
+        parameters=dict(type="raw", required=True),
     )
 
-    result = {'changed': False, 'failed': False}
+    result = {"changed": False, "failed": False}
 
     module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
-    result['rpc_url'] = module.params['rpc_url']
-    result['contract_addr'] = module.params['contract_addr']
-    result['abi'] = module.params['abi']
-    result['function_sig'] = module.params['function_sig']
-    result['parameters'] = module.params['parameters']
+    result["rpc_url"] = module.params["rpc_url"]
+    result["contract_addr"] = module.params["contract_addr"]
+    result["abi"] = module.params["abi"]
+    result["function_sig"] = module.params["function_sig"]
+    result["parameters"] = module.params["parameters"]
 
     try:
         cast_parameters(result)
-        if result['failed']:
+        if result["failed"]:
             module.exit_json(**result)
 
         eth_call(result)
-        result.pop('casted_params')
+        result.pop("casted_params")
 
         module.exit_json(**result)
 
@@ -86,5 +86,5 @@ def main():
         module.fail_json(msg=to_native(traceback.format_exc()))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 collections:
   - name: prometheus.prometheus

--- a/roles/ash_cli/defaults/main.yml
+++ b/roles/ash_cli/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Ash CLI version
 ash_cli_version: 0.3.0

--- a/roles/ash_cli/tasks/config-custom-network.yml
+++ b/roles/ash_cli/tasks/config-custom-network.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Parameters
 # - network: The custom network to add. Should have the following structure:

--- a/roles/ash_cli/tasks/config.yml
+++ b/roles/ash_cli/tasks/config.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Initialize the default Ash CLI configuration
   command:

--- a/roles/ash_cli/tasks/install.yml
+++ b/roles/ash_cli/tasks/install.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Create Ash CLI directories
   file:

--- a/roles/ash_cli/tasks/main.yml
+++ b/roles/ash_cli/tasks/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install Ash CLI
   import_tasks: install.yml

--- a/roles/ash_cli/templates/ash-command.j2
+++ b/roles/ash_cli/templates/ash-command.j2
@@ -1,5 +1,5 @@
 {# SPDX-License-Identifier: BSD-3-Clause
-Copyright (c) 2022-2023, E36 Knots #}
+Copyright (c) 2022-2024, E36 Knots #}
 #!/bin/bash
 
 ASH_CONFIG={{ ash_cli_conf_dir }}/default.yml AVALANCHE_NETWORK={{ ash_cli_avalanche_network_id }} {{ ash_cli_bin_dir }}/ash "$@"

--- a/roles/ash_cli/vars/main.yml
+++ b/roles/ash_cli/vars/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 ash_cli_binary_arch: amd64
 ash_cli_binary_name: "ash-linux-{{ ash_cli_binary_arch }}-v{{ ash_cli_version }}.tar.gz"

--- a/roles/evm/blockscout/defaults/main.yml
+++ b/roles/evm/blockscout/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Blockscout version
 blockscout_image: blockscout/blockscout

--- a/roles/evm/blockscout/handlers/main.yml
+++ b/roles/evm/blockscout/handlers/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Restart blockscout
   service:

--- a/roles/evm/blockscout/tasks/config-blockscout.yml
+++ b/roles/evm/blockscout/tasks/config-blockscout.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Create Blockscout directories
   file:

--- a/roles/evm/blockscout/tasks/main.yml
+++ b/roles/evm/blockscout/tasks/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Configure Blockscout Docker
   include_tasks: config-blockscout.yml

--- a/roles/evm/blockscout/tasks/start-blockscout.yml
+++ b/roles/evm/blockscout/tasks/start-blockscout.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Start and enable blockscout.service
   service:

--- a/roles/faucet/defaults/main.yml
+++ b/roles/faucet/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Avalanche Faucet version
 avalanche_faucet_image: ghcr.io/ashavalanche/faucet-image

--- a/roles/faucet/handlers/main.yml
+++ b/roles/faucet/handlers/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Restart avalanche-faucet
   service:

--- a/roles/faucet/tasks/config-faucet.yml
+++ b/roles/faucet/tasks/config-faucet.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Template config.json file
   template:

--- a/roles/faucet/tasks/install-faucet.yml
+++ b/roles/faucet/tasks/install-faucet.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: "Create {{ avalanche_faucet_group }} group"
   group:

--- a/roles/faucet/tasks/main.yml
+++ b/roles/faucet/tasks/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install Faucet
   include_tasks: install-faucet.yml

--- a/roles/faucet/tasks/start-faucet.yml
+++ b/roles/faucet/tasks/start-faucet.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Start and enable avalanche-faucet.service
   service:

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Avalanchego version
 avalanchego_version: 1.10.0
@@ -13,7 +13,7 @@ avalanchego_db_dir: /var/lib/avalanche/avalanchego/db
 
 # Configuration directories
 avalanchego_conf_dir: /etc/avalanche/avalanchego/conf
-avalanchego_staking_certs_dir: /etc/avalanche/avalanchego/staking
+avalanchego_staking_dir: /etc/avalanche/avalanchego/staking
 avalanchego_https_certs_dir: /etc/ssl/certs/avalanche/avalanchego
 avalanchego_gpg_dir: /etc/avalanche/avalanchego/gnupg
 
@@ -49,6 +49,14 @@ avalanchego_staking_port: 9651
 ## If set to `true`, will use existing certificates found in `avalanchego_staking_local_certs_dir`
 avalanchego_staking_use_local_certs: false
 avalanchego_staking_local_certs_dir: "{{ playbook_dir }}/files/staking"
+## If set to `true`, will use existing BLS keys found in `avalanchego_staking_local_bls_keys_dir`
+avalanchego_staking_use_local_bls_keys: false
+avalanchego_staking_local_bls_keys_dir: "{{ playbook_dir }}/files/staking"
+
+# Genesis
+## If set to `true`, will use existing genesis file at `avalanchego_custom_genesis_local_file`
+avalanchego_custom_genesis: false
+avalanchego_custom_genesis_local_file: "{{ playbook_dir }}/files/genesis.json"
 
 # Bootstrapping
 avalanchego_network_id: fuji
@@ -151,4 +159,4 @@ avalanchego_service_options: |
 ## Whether to install and configure Ash CLI on the node
 ash_cli_install: true
 ## The avalanche network to be used in the Ash CLI (sets the RPC endpoints to use)
-ash_cli_network_id: fuji
+ash_cli_network_id: "{{ avalanchego_network_id }}"

--- a/roles/node/handlers/main.yml
+++ b/roles/node/handlers/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Restart avalanchego
   service:

--- a/roles/node/tasks/add-validator.yml
+++ b/roles/node/tasks/add-validator.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 ## /!\ Cannot be used on mainnet /!\
 # Parameters

--- a/roles/node/tasks/bootstrap-db.yml
+++ b/roles/node/tasks/bootstrap-db.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Unpack bootstrap database
   unarchive:

--- a/roles/node/tasks/clean-plugins-dir.yml
+++ b/roles/node/tasks/clean-plugins-dir.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: "Get symlinks in {{ avalanchego_plugins_dir }}"
   find:

--- a/roles/node/tasks/config-chains.yml
+++ b/roles/node/tasks/config-chains.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Create chains conf directories
   file:

--- a/roles/node/tasks/config-node.yml
+++ b/roles/node/tasks/config-node.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Set bootstrap_ips variable
   set_fact:
@@ -19,13 +19,27 @@
              else (avalanchego_bootstrap_node_ids | join(','))
          } if avalanchego_network_id not in ['mainnet', 'testnet', 'fuji'] else {} }}
 
+- name: Construct genesis-file conf
+  set_fact:
+    node_conf_genesis_file: |
+      {{ {
+           'genesis-file': avalanchego_conf_dir + '/genesis.json'
+         } if avalanchego_custom_genesis else {} }}
+
 - name: Construct staking-tls-*-file conf
   set_fact:
     node_conf_staking_tls_files: |
       {{ {
-           'staking-tls-cert-file': avalanchego_staking_certs_dir + '/node.crt',
-           'staking-tls-key-file': avalanchego_staking_certs_dir + '/node.key'
+           'staking-tls-cert-file': avalanchego_staking_dir + '/staker.crt',
+           'staking-tls-key-file': avalanchego_staking_dir + '/staker.key'
          } if avalanchego_staking_use_local_certs else {} }}
+
+- name: Construct staking-signer-key-file conf
+  set_fact:
+    node_conf_staking_signer_key_file: |
+      {{ {
+           'staking-signer-key-file': avalanchego_staking_dir + '/signer.key'
+         } if avalanchego_staking_use_local_bls_keys else {} }}
 
 - name: Construct http-tls-*-file conf
   set_fact:
@@ -40,7 +54,9 @@
     node_conf_json: |
       {{ (
         node_conf_bootstrap,
+        node_conf_genesis_file,
         node_conf_staking_tls_files,
+        node_conf_staking_signer_key_file,
         node_conf_http_tls_files
         ) | combine(avalanchego_node_json) }}
 
@@ -52,10 +68,18 @@
     group: "{{ avalanchego_group }}"
   notify: Restart avalanchego
 
+- name: Upload genesis.json
+  copy:
+    src: "{{ avalanchego_custom_genesis_local_file }}"
+    dest: "{{ avalanchego_conf_dir }}/genesis.json"
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
+  when: avalanchego_custom_genesis
+
 - name: Upload node staking certificates
   copy:
     src: "{{ avalanchego_staking_local_certs_dir }}/{{ inventory_hostname }}.{{ item }}"
-    dest: "{{ avalanchego_staking_certs_dir }}/node.{{ item }}"
+    dest: "{{ avalanchego_staking_dir }}/staker.{{ item }}"
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"
     mode: 0400
@@ -63,6 +87,16 @@
     - crt
     - key
   when: avalanchego_staking_use_local_certs
+  notify: Restart avalanchego
+
+- name: Upload node staking BLS keys
+  copy:
+    src: "{{ avalanchego_staking_local_bls_keys_dir }}/{{ inventory_hostname }}.bls.key"
+    dest: "{{ avalanchego_staking_dir }}/signer.key"
+    owner: "{{ avalanchego_user }}"
+    group: "{{ avalanchego_group }}"
+    mode: 0400
+  when: avalanchego_staking_use_local_bls_keys
   notify: Restart avalanchego
 
 # Handle TLS certificates for HTTPS

--- a/roles/node/tasks/config-subnets.yml
+++ b/roles/node/tasks/config-subnets.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Generate subnets JSON config files
   copy:

--- a/roles/node/tasks/health-checks.yml
+++ b/roles/node/tasks/health-checks.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Run health checks on the node
 # Parameters:

--- a/roles/node/tasks/install-avalanchego.yml
+++ b/roles/node/tasks/install-avalanchego.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: "Check that AvalancheGo {{ avalanchego_version }} is supported"
   debug:
@@ -29,7 +29,7 @@
     - "{{ avalanchego_subnets_conf_dir }}"
     - "{{ avalanchego_chains_conf_dir }}"
     - "{{ avalanchego_vms_conf_dir }}"
-    - "{{ avalanchego_staking_certs_dir }}"
+    - "{{ avalanchego_staking_dir }}"
     - "{{ avalanchego_https_certs_dir }}"
     - "{{ avalanchego_log_dir }}"
     - "{{ avalanchego_gpg_dir }}"

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Set avalanchego_vm_binary_arch according to ansible_architecture
   set_fact:

--- a/roles/node/tasks/install-vms.yml
+++ b/roles/node/tasks/install-vms.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install VMs
   include_tasks: install-vm.yml

--- a/roles/node/tasks/main.yml
+++ b/roles/node/tasks/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Install AvalancheGo
   import_tasks: install-avalanchego.yml
@@ -66,13 +66,13 @@
     - ash_cli
     - install-ash_cli
   vars:
-    ash_cli_avalanche_network_id: "{{ avalanchego_network_id }}"
+    ash_cli_avalanche_network_id: "{{ ash_cli_network_id }}"
   when: ash_cli_install
 
-- name: Generate Ash CLI local network configuration
+- name: Generate Ash CLI local network configuration (1/2)
   set_fact:
-    ash_cli_networks:
-      local:
+    ash_cli_networks: |
+      {{ avalanchego_network_id }}:
         pchain_rpc_url: "{{ ash_cli_local_endpoint }}/ext/bc/P"
         cchain_rpc_url: "{{ ash_cli_local_endpoint }}/ext/bc/C/rpc"
         xchain_rpc_url: "{{ ash_cli_local_endpoint }}/ext/bc/X"
@@ -84,7 +84,18 @@
     ash_cli_local_endpoint: "{{ 'https' if avalanchego_https_enabled else 'http' }}://{{ '127.0.0.1' if avalanchego_http_host == '0.0.0.0' else avalanchego_http_host }}:{{ avalanchego_http_port }}"
   when:
     - ash_cli_install
-    - avalanchego_network_id == 'local'
+    - avalanchego_network_id not in ['mainnet', 'testnet', 'fuji']
+
+- name: Generate Ash CLI local network configuration (2/2)
+  set_fact:
+    ash_cli_networks: "{{ ash_cli_networks | from_yaml }}"
+  tags:
+    - config
+    - ash_cli
+    - config-ash_cli
+  when:
+    - ash_cli_install
+    - avalanchego_network_id not in ['mainnet', 'testnet', 'fuji']
 
 - name: Configure Ash CLI
   import_role:

--- a/roles/node/tasks/restart.yml
+++ b/roles/node/tasks/restart.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Restart avalanchego.service
   service:

--- a/roles/node/tasks/start.yml
+++ b/roles/node/tasks/start.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Start and enable avalanchego.service
   service:

--- a/roles/node/tasks/stop.yml
+++ b/roles/node/tasks/stop.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Stop avalanchego.service
   service:

--- a/roles/node/templates/avalanchego.service.j2
+++ b/roles/node/templates/avalanchego.service.j2
@@ -1,5 +1,5 @@
 {# SPDX-License-Identifier: BSD-3-Clause
-Copyright (c) 2022-2023, E36 Knots #}
+Copyright (c) 2022-2024, E36 Knots #}
 [Unit]
 Description=AvalancheGo systemd service
 After=network.target

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # AvalancheGo version
 avalanchego_min_version: 1.9.6

--- a/roles/subnet/defaults/main.yml
+++ b/roles/subnet/defaults/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # Subnet configuration
 subnet_avalanche_network_id: local
@@ -43,7 +43,7 @@ subnet_blockchains_list:
   ##         targetBlockRate: 2
   ##         blockGasCostStep: 200000
   ##     alloc:
-  ##       8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC:
+  ##       "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC":
   ##         balance: "0x295BE96E64066972000000"
   ##     nonce: "0x0"
   ##     timestamp: "0x0"

--- a/roles/subnet/tasks/add-validator.yml
+++ b/roles/subnet/tasks/add-validator.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # /!\ Cannot be used on mainnet /!\
 # Parameters

--- a/roles/subnet/tasks/add-validators.yml
+++ b/roles/subnet/tasks/add-validators.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # /!\ Cannot be used on mainnet /!\
 # Parameters

--- a/roles/subnet/tasks/create-blockchain.yml
+++ b/roles/subnet/tasks/create-blockchain.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # /!\ Cannot be used on mainnet /!\
 # Parameters

--- a/roles/subnet/tasks/create-blockchains.yml
+++ b/roles/subnet/tasks/create-blockchains.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Create the blockchains
   include_tasks: create-blockchain.yml

--- a/roles/subnet/tasks/create-subnet.yml
+++ b/roles/subnet/tasks/create-subnet.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 # /!\ Cannot be used on mainnet /!\
 - name: Create the Subnet

--- a/roles/subnet/tasks/main.yml
+++ b/roles/subnet/tasks/main.yml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Check that Ash CLI is installed
   shell: ash help

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -1,7 +1,7 @@
 #!/bin/python3
 
 # SPDX-License-Identifier: BSD-3-Clause
-# Copyright (c) 2022-2023, E36 Knots
+# Copyright (c) 2022-2024, E36 Knots
 
 import os
 import requests
@@ -12,30 +12,30 @@ from packaging import version
 # Update the avalanchego_vms_list variable in roles/node/vars
 # with new VM versions available and their compatibility with AvalancheGo
 
-GITHUB_RAW_URL = 'https://raw.githubusercontent.com'
-GITHUB_API_URL = 'https://api.github.com'
+GITHUB_RAW_URL = "https://raw.githubusercontent.com"
+GITHUB_API_URL = "https://api.github.com"
 
-VARS_YAML_PATH = '../roles/node/vars/main.yml'
+VARS_YAML_PATH = "../roles/node/vars/main.yml"
 VARS_YAML_HEADER_SIZE = 3
 VMS_REPOS = {
-    'subnet-evm': 'ava-labs/subnet-evm',
+    "subnet-evm": "ava-labs/subnet-evm",
 }
-MIN_AVAX_VERSION = '1.9.6'
+MIN_AVAX_VERSION = "1.9.6"
 
 vms_versions_comp = {}
 
 # For each VM, fetch AvalancheGo compatibility info from README
 for vm, repo in VMS_REPOS.items():
-    repo_info = requests.get(f'{GITHUB_API_URL}/repos/{repo}')
-    default_branch = repo_info.json()['default_branch']
+    repo_info = requests.get(f"{GITHUB_API_URL}/repos/{repo}")
+    default_branch = repo_info.json()["default_branch"]
 
-    readme_url = f'{GITHUB_RAW_URL}/{repo}/{default_branch}/README.md'
+    readme_url = f"{GITHUB_RAW_URL}/{repo}/{default_branch}/README.md"
     readme_raw = requests.get(readme_url)
 
     compatibility_specs = list(
         re.finditer(
-            r'^\[v(?P<vm_start_ver>\d+\.\d+\.\d+)-?v?(?P<vm_end_ver>\d+\.\d+\.\d+)?\] '
-            r'AvalancheGo@v(?P<avax_start_ver>\d+\.\d+\.\d+)-?v?(?P<avax_end_ver>\d+\.\d+\.\d+)?',
+            r"^\[v(?P<vm_start_ver>\d+\.\d+\.\d+)-?v?(?P<vm_end_ver>\d+\.\d+\.\d+)?\] "
+            r"AvalancheGo@v(?P<avax_start_ver>\d+\.\d+\.\d+)-?v?(?P<avax_end_ver>\d+\.\d+\.\d+)?",
             readme_raw.text,
             flags=re.MULTILINE,
         )
@@ -44,21 +44,21 @@ for vm, repo in VMS_REPOS.items():
     # Iterate on all versions
     versions_comp = {}
     for c in compatibility_specs:
-        vm_start_ver = version.parse(c.group('vm_start_ver'))
-        vm_end_ver = version.parse(c.group('vm_end_ver') or c.group('vm_start_ver'))
+        vm_start_ver = version.parse(c.group("vm_start_ver"))
+        vm_end_ver = version.parse(c.group("vm_end_ver") or c.group("vm_start_ver"))
 
         for major in range(vm_start_ver.major, vm_end_ver.major + 1):
             for minor in range(vm_start_ver.minor, vm_end_ver.minor + 1):
                 for micro in range(vm_start_ver.micro, vm_end_ver.micro + 1):
-                    if version.parse(c.group('avax_start_ver')) >= version.parse(
+                    if version.parse(c.group("avax_start_ver")) >= version.parse(
                         MIN_AVAX_VERSION
                     ):
                         versions_comp.update(
                             {
-                                f'{major}.{minor}.{micro}': {
-                                    'ge': c.group('avax_start_ver'),
-                                    'le': c.group('avax_end_ver')
-                                    or c.group('avax_start_ver'),
+                                f"{major}.{minor}.{micro}": {
+                                    "ge": c.group("avax_start_ver"),
+                                    "le": c.group("avax_end_ver")
+                                    or c.group("avax_start_ver"),
                                 }
                             }
                         )
@@ -70,12 +70,12 @@ vars_yaml_abs_path = os.path.join(
 )
 
 with open(vars_yaml_abs_path) as vars_yaml:
-    vars_header = ''.join([vars_yaml.readline() for l in range(VARS_YAML_HEADER_SIZE)])
+    vars_header = "".join([vars_yaml.readline() for l in range(VARS_YAML_HEADER_SIZE)])
     vars_obj = yaml.load(vars_yaml, Loader=yaml.CLoader)
 
 # Enrich the avalanchego_vms_list with updated versions_comp
 for vm, v_comp in vms_versions_comp.items():
-    vars_obj['avalanchego_vms_list'][vm]['versions_comp'] = v_comp
+    vars_obj["avalanchego_vms_list"][vm]["versions_comp"] = v_comp
 
-with open(vars_yaml_abs_path + '.updated', 'w') as vars_yaml:
+with open(vars_yaml_abs_path + ".updated", "w") as vars_yaml:
     vars_yaml.write(vars_header + yaml.dump(vars_obj, Dumper=yaml.CDumper))


### PR DESCRIPTION
### Changes

- `avalanche.node`
  - Support providing a BLS key as staking key (used by AWM)
  - Support providing a custom genesis file to create a custom network (not `mainnet`, `testnet|fuji` or `local`)
- Update license header

### Breaking changes

- `avalanche.node`
  - Rename `node.(crt|key)` to `staker.(crt|key)` to match AvalancheGo default

### Additional comment

The BLS key file for a node has to be provided as `{{ inventory_hostname }}.bls.key` in the local staking dir.