### PR TITLE
fix: allow the removing of outdated links when emptying avalanchego_p…

### DIFF
--- a/roles/node/tasks/clean-plugins-dir.yml
+++ b/roles/node/tasks/clean-plugins-dir.yml
@@ -16,7 +16,7 @@
   file:
     path: "{{ item.path }}"
     state: absent
-  when: (item.path | basename) not in expected_plugins
+  when: (item.path | basename) not in (expected_plugins | default([]))
   loop: "{{ links.files }}"
   loop_control:
     label: "{{ item.path }}"


### PR DESCRIPTION
### Changes

- Added the default value of expected_plugins when emptying vms in the avalanchego_plugins_dir to remove all the vms install on each node.

### Additional comments

This fix take care of the bug when following the 'Uninstall a VM' chapter of the tutorial on Ansible Avalanche Collection.
