### PR TITLE
feat: add + use vm_version_compat module

### DIFF
--- a/plugins/modules/vm_version_compat.py
+++ b/plugins/modules/vm_version_compat.py
@@ -1,0 +1,94 @@
+#!/usr/bin/python
+
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2024, E36 Knots
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import Request
+
+GITHUB_RAW_URL = "https://raw.githubusercontent.com"
+GITHUB_API_URL = "https://api.github.com"
+
+
+def get_json(url):
+    r = Request()
+
+    return json.loads(r.get(url).read())
+
+
+def run_module():
+    # Define module arguments
+    module_args = dict(
+        vm_gh_repo=dict(type="str", required=True),
+        vm_version=dict(type="str", required=True),
+        avalanche_gh_repo=dict(type="str", required=True),
+        avalanche_version=dict(type="str", required=True),
+        strict=dict(type="bool", required=False, default=False),
+    )
+
+    # Define result argument
+    result = dict(changed=False)
+
+    # Create the module instance
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    vm_repo = module.params["vm_gh_repo"]
+    vm_version = module.params["vm_version"]
+    avax_repo = module.params["avalanche_gh_repo"]
+    avax_version = module.params["avalanche_version"]
+
+    vm_compat_json_url = f"{GITHUB_RAW_URL}/{vm_repo}/{vm_version}/compatibility.json"
+    avax_compat_json_url = (
+        f"{GITHUB_RAW_URL}/{avax_repo}/{avax_version}/version/compatibility.json"
+    )
+
+    try:
+        vm_compat_json = get_json(vm_compat_json_url)
+    except Exception as e:
+        module.fail_json(
+            msg=f"Failed to get compatibility JSON at {vm_compat_json_url}: {e}"
+        )
+
+    try:
+        avax_compat_json = get_json(avax_compat_json_url)
+    except Exception as e:
+        module.fail_json(
+            msg=f"Failed to get compatibility JSON at {avax_compat_json_url}: {e}"
+        )
+
+    vm_rpcchainvm_proto_version = int(
+        vm_compat_json["rpcChainVMProtocolVersion"][vm_version]
+    )
+    for rpc_ver, avax_ver in avax_compat_json.items():
+        if avax_version in avax_ver:
+            avax_rpcchainvm_proto_version = int(rpc_ver)
+            break
+
+    result["vm_rpcchainvm_proto_version"] = vm_rpcchainvm_proto_version
+    result["avalanche_rpcchainvm_proto_version"] = avax_rpcchainvm_proto_version
+    result["is_compatible"] = (
+        vm_rpcchainvm_proto_version == avax_rpcchainvm_proto_version
+    )
+
+    if module.params["strict"] and not result["is_compatible"]:
+        module.fail_json(
+            msg="VM and AvalancheGo versions are not compatible",
+            **result,
+        )
+
+    # Exit with the result if there was no error
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -88,8 +88,6 @@ avalanchego_node_json:
   staking-port: "{{ avalanchego_staking_port }}"
   # Consensus
   network-id: "{{ avalanchego_network_id }}"
-  snow-sample-size: 20
-  snow-quorum-size: 15
   # Paths
   db-dir: "{{ avalanchego_db_dir }}"
   subnet-config-dir: "{{ avalanchego_subnets_conf_dir }}"

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -5,29 +5,29 @@
   set_fact:
     avalanchego_vm_binary_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else avalanchego_vm_binary_arch }}"
 
-- name: Check that only one of `versions_comp_gh_repo` and `versions_comp_static` is defined
+- name: Check that only one of `versions_comp_gh_repo` and `versions_comp` is defined
   assert:
-    that: "(vm_info.version_comp_gh_repo) is defined != (vm_info.version_comp_static is defined)"
-    msg: "Only one of `version_comp_gh_repo` and `version_comp_static` must be defined"
-    fail_msg: "Both `version_comp_gh_repo` and `version_comp_static` are defined"
-    success_msg: "Only one of `version_comp_gh_repo` and `version_comp_static` is defined"
+    that: "(vm_info.versions_comp_gh_repo) is defined != (vm_info.versions_comp is defined)"
+    msg: "Only one of `versions_comp_gh_repo` and `versions_comp` must be defined"
+    fail_msg: "Both `versions_comp_gh_repo` and `versions_comp` are defined"
+    success_msg: "Only one of `versions_comp_gh_repo` and `versions_comp` is defined"
 
 - name: "Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}"
   debug:
     msg: "AvalancheGo version {{ item.key }} {{ item.value }}: {{ avalanchego_version is version(item.value, item.key) }}"
   run_once: true
-  loop: "{{ vm_info.version_comp_static[vm_version] | dict2items }}"
+  loop: "{{ vm_info.versions_comp[vm_version] | dict2items }}"
   failed_when: not avalanchego_version is version(item.value, item.key)
-  when: vm_info.version_comp_static is defined
+  when: vm_info.versions_comp is defined
 
 - name: "Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}"
   ash.avalanche.vm_version_compat:
-    vm_gh_repo: "{{ vm_info.version_comp_gh_repo }}"
+    vm_gh_repo: "{{ vm_info.versions_comp_gh_repo }}"
     vm_version: "v{{ vm_version }}"
     avalanche_gh_repo: "{{ avalanchego_gh_repo }}"
     avalanche_version: "v{{ avalanchego_version }}"
     strict: true
-  when: vm_info.version_comp_gh_repo is defined
+  when: vm_info.versions_comp_gh_repo is defined
 
 - name: "Create {{ vm_name }} dir"
   file:

--- a/roles/node/tasks/install-vm.yml
+++ b/roles/node/tasks/install-vm.yml
@@ -5,12 +5,29 @@
   set_fact:
     avalanchego_vm_binary_arch: "{{ 'amd64' if ansible_architecture == 'x86_64' else 'arm64' if ansible_architecture == 'aarch64' else avalanchego_vm_binary_arch }}"
 
+- name: Check that only one of `versions_comp_gh_repo` and `versions_comp_static` is defined
+  assert:
+    that: "(vm_info.version_comp_gh_repo) is defined != (vm_info.version_comp_static is defined)"
+    msg: "Only one of `version_comp_gh_repo` and `version_comp_static` must be defined"
+    fail_msg: "Both `version_comp_gh_repo` and `version_comp_static` are defined"
+    success_msg: "Only one of `version_comp_gh_repo` and `version_comp_static` is defined"
+
 - name: "Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}"
   debug:
     msg: "AvalancheGo version {{ item.key }} {{ item.value }}: {{ avalanchego_version is version(item.value, item.key) }}"
   run_once: true
-  loop: "{{ vm_info.versions_comp[vm_version] | dict2items }}"
+  loop: "{{ vm_info.version_comp_static[vm_version] | dict2items }}"
   failed_when: not avalanchego_version is version(item.value, item.key)
+  when: vm_info.version_comp_static is defined
+
+- name: "Check that {{ vm_name }}={{ vm_version }} is compatible with avalanchego={{ avalanchego_version }}"
+  ash.avalanche.vm_version_compat:
+    vm_gh_repo: "{{ vm_info.version_comp_gh_repo }}"
+    vm_version: "v{{ vm_version }}"
+    avalanche_gh_repo: "{{ avalanchego_gh_repo }}"
+    avalanche_version: "v{{ avalanchego_version }}"
+    strict: true
+  when: vm_info.version_comp_gh_repo is defined
 
 - name: "Create {{ vm_name }} dir"
   file:
@@ -19,12 +36,12 @@
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"
 
-- name: "Check if only one of {{ vm_info.download_url }} and {{ vm_info.path }} is defined"
+- name: Check that only one of `download_url` and `path` is defined
   assert:
     that: "vm_info.download_url is defined != vm_info.path is defined"
-    msg: "Only one of vm_info.download_url and vm_info.path must be defined"
-    fail_msg: "Both vm_info.download_url and vm_info.path are defined"
-    success_msg: "Only one of vm_info.download_url and vm_info.path is defined"
+    msg: "Only one of `download_url` and `path` must be defined"
+    fail_msg: "Both `download_url` and `path` are defined"
+    success_msg: "Only one of `download_url` and `path` is defined"
 
 - name: "Download {{ vm_name }} {{ vm_version }} binary"
   get_url:

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -3,9 +3,10 @@
 ---
 # AvalancheGo version
 avalanchego_min_version: 1.10.0
+avalanchego_gh_repo: ava-labs/avalanchego
 avalanchego_binary_arch: amd64
 avalanchego_binary_name: "avalanchego-linux-{{ avalanchego_binary_arch }}-v{{ avalanchego_version }}.tar.gz"
-avalanchego_binary_url: "https://github.com/ava-labs/avalanchego/releases/download/v{{ avalanchego_version }}/{{ avalanchego_binary_name }}"
+avalanchego_binary_url: "https://github.com/{{ avalanchego_gh_repo }}/releases/download/v{{ avalanchego_version }}/{{ avalanchego_binary_name }}"
 
 # AvalancheGo GPG key
 avalanchego_gpg_key_name: avalanchego.gpg.key
@@ -41,51 +42,12 @@ avalanchego_vms_list:
     ash_vm_type: SubnetEVM
     # The VM binary filename
     binary_filename: subnet-evm
-    versions_comp:
-      # Protocol version: 25
-      0.5.0:
-        ge: 1.10.0
-        le: 1.10.0
-      # Protocol version: 26
-      0.5.1:
-        ge: 1.10.1
-        le: 1.10.4
-      0.5.2:
-        ge: 1.10.1
-        le: 1.10.4
-      # Protocol version: 27
-      0.5.3:
-        ge: 1.10.5
-        le: 1.10.8
-      # Protocol version: 28
-      0.5.5:
-        ge: 1.10.9
-        le: 1.10.12
-      0.5.6:
-        ge: 1.10.9
-        le: 1.10.12
-      # Protocol version: 29
-      0.5.7:
-        ge: 1.10.13
-        le: 1.10.14
-      0.5.8:
-        ge: 1.10.13
-        le: 1.10.14
-      # Protocol version: 30
-      0.5.9:
-        ge: 1.10.15
-        le: 1.10.17
-      0.5.10:
-        ge: 1.10.15
-        le: 1.10.17
-      # Protocol version: 31
-      0.5.11:
-        ge: 1.10.18
-        le: 1.10.19
-      # Protocol version: 33
-      0.6.0-fuji:
-        ge: 1.11.0-fuji
-        le: 1.11.0-fuji
-      0.6.1:
-        ge: 1.11.1
-        le: 1.11.1
+    # Only one of `version_comp_repo` or `version_comp_static`
+    # The GitHub repository where to find the `compatibility.json` file
+    version_comp_gh_repo: ava-labs/subnet-evm
+    # The static compatibility matrix
+    # Example:
+    # versions_comp_static:
+    #   0.5.0:
+    #     ge: 1.10.0
+    #     le: 1.10.0

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -42,12 +42,12 @@ avalanchego_vms_list:
     ash_vm_type: SubnetEVM
     # The VM binary filename
     binary_filename: subnet-evm
-    # Only one of `version_comp_repo` or `version_comp_static`
+    # Only one of `versions_comp_repo` or `versions_comp`
     # The GitHub repository where to find the `compatibility.json` file
-    version_comp_gh_repo: ava-labs/subnet-evm
+    versions_comp_gh_repo: ava-labs/subnet-evm
     # The static compatibility matrix
     # Example:
-    # versions_comp_static:
+    # versions_comp:
     #   0.5.0:
     #     ge: 1.10.0
     #     le: 1.10.0

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -20,7 +20,7 @@ VARS_YAML_HEADER_SIZE = 3
 VMS_REPOS = {
     "subnet-evm": "ava-labs/subnet-evm",
 }
-MIN_AVAX_VERSION = "1.9.6"
+MIN_AVAX_VERSION = "1.10.0"
 
 vms_versions_comp = {}
 
@@ -77,5 +77,5 @@ with open(vars_yaml_abs_path) as vars_yaml:
 for vm, v_comp in vms_versions_comp.items():
     vars_obj["avalanchego_vms_list"][vm]["versions_comp"] = v_comp
 
-with open(vars_yaml_abs_path + ".updated", "w") as vars_yaml:
+with open(vars_yaml_abs_path + ".updated.yml", "w") as vars_yaml:
     vars_yaml.write(vars_header + yaml.dump(vars_obj, Dumper=yaml.CDumper))


### PR DESCRIPTION
### Linked issues

- Fixes #128 
- Fixes #127 

### Changes

- Add the `vm_version_compat` module that dynamically checks that an Avalanche VM version is compatible with an AvalancheGo version. It uses `compatibility.json` files to do so
- Use `vm_version_compat` by default for VM compatibility check. The existing behavior is still supported.

### Additional comments

The compatibility files are expected at the root of the VM repo (e.g. [subnet-evm](https://github.com/ava-labs/subnet-evm/blob/master/compatibility.json)) and in the [version/](https://github.com/ava-labs/avalanchego/blob/master/version/compatibility.json) folder of AvalancheGo.
