### PR TITLE
fix(blockscout): add tags on playbook

### DIFF
--- a/playbooks/install_blockscout_docker.yml
+++ b/playbooks/install_blockscout_docker.yml
@@ -6,4 +6,8 @@
   become: true
   roles:
     - role: geerlingguy.docker
+      tags: 
+        - install
+        - blockscout
+        - install-blockscout
     - role: ash.avalanche.evm.blockscout

--- a/roles/evm/blockscout/defaults/main.yml
+++ b/roles/evm/blockscout/defaults/main.yml
@@ -2,6 +2,10 @@
 # Copyright (c) 2022-2024, E36 Knots
 ---
 
+# Auto-restart
+## The restart is triggered by any version or configuration change
+blockscout_auto_restart: true
+
 # Configuration directories
 blockscout_conf_dir: /etc/blockscout/conf
 blockscout_custom_dir: "{{ blockscout_conf_dir }}/custom"

--- a/roles/evm/blockscout/handlers/main.yml
+++ b/roles/evm/blockscout/handlers/main.yml
@@ -5,3 +5,5 @@
   service:
     name: blockscout
     state: restarted
+  when:
+  - skip_handlers | default("false") == "false"

--- a/roles/evm/blockscout/handlers/main.yml
+++ b/roles/evm/blockscout/handlers/main.yml
@@ -5,5 +5,4 @@
   service:
     name: blockscout
     state: restarted
-  when:
-  - skip_handlers | default("false") == "false"
+  when: blockscout_auto_restart

--- a/roles/evm/blockscout/tasks/main.yml
+++ b/roles/evm/blockscout/tasks/main.yml
@@ -2,14 +2,18 @@
 # Copyright (c) 2022-2024, E36 Knots
 ---
 - name: Configure Blockscout Docker
-  include_tasks: config-blockscout.yml
+  import_tasks: config-blockscout.yml
+  tags:
+    - config
+    - blockscout
+    - config-blockscout
 
 - name: Restart Blockscout Docker if needed
   meta: flush_handlers
-  tags:
-    - Restart
-    - blockscout
-    - Restart-blockscout
 
 - name: Start Blockscout Docker
   include_tasks: start-blockscout.yml
+  tags:
+    - start
+    - blockscout
+    - start-blockscout


### PR DESCRIPTION
### Changes

- Add install, configure and start tags on Blockscout playbook.
- Add env var execution condition on restart handler as tags isn't applied on it:
     ansible-playbook ash.avalanche.install_blockscout_docker -i inventories/local -t "config" -e skip_handlers=true 