### PR TITLE
feat: upgrade avalanchego version

### DIFF
--- a/roles/ash_cli/defaults/main.yml
+++ b/roles/ash_cli/defaults/main.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2022-2024, E36 Knots
 ---
 # Ash CLI version
-ash_cli_version: 0.4.1
+ash_cli_version: 0.4.3
 
 # Directories
 ash_cli_install_dir: /opt/avalanche/ash-cli

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2022-2024, E36 Knots
 ---
 # Avalanchego version
-avalanchego_version: 1.10.0
+avalanchego_version: 1.11.3
 
 # Install directories
 avalanchego_install_dir: /opt/avalanche/avalanchego

--- a/roles/node/vars/main.yml
+++ b/roles/node/vars/main.yml
@@ -2,7 +2,7 @@
 # Copyright (c) 2022-2024, E36 Knots
 ---
 # AvalancheGo version
-avalanchego_min_version: 1.10.0
+avalanchego_min_version: 1.11.3
 avalanchego_gh_repo: ava-labs/avalanchego
 avalanchego_binary_arch: amd64
 avalanchego_binary_name: "avalanchego-linux-{{ avalanchego_binary_arch }}-v{{ avalanchego_version }}.tar.gz"

--- a/roles/subnet/tasks/add-validator.yml
+++ b/roles/subnet/tasks/add-validator.yml
@@ -44,20 +44,6 @@
   set_fact:
     node_is_validator: "{{ validators_list_res.output | json_query('[?nodeID==`' + node_id + '`]') | length > 0 }}"
 
-- name: Check if the node is a pending validator (1/2)
-  ash.avalanche.ash_cmd:
-    command: avalanche validator list
-    options:
-      subnet-id: "{{ subnet_id }}"
-      pending: true
-  environment:
-    AVALANCHE_NETWORK: "{{ subnet_avalanche_network_id }}"
-  register: pending_validators_list_res
-
-- name: Check if the node is a pending validator (2/2)
-  set_fact:
-    node_is_pending_validator: "{{ pending_validators_list_res.output | json_query('[?nodeID==`' + node_id + '`]') | length > 0 }}"
-
 # Primary Network (requires `signer`)
 - name: "Add '{{ node_id }}' as validator if it is not already (Primary Network)"
   ash.avalanche.ash_cmd:
@@ -74,7 +60,6 @@
     AVALANCHE_KEY_ENCODING: "{{ subnet_txs_key_encoding }}"
   when:
     - not node_is_validator
-    - not node_is_pending_validator
     - subnet_id == avalanche_primary_network_id
 
 # Other Subnets (does not require `signer`)
@@ -92,5 +77,4 @@
     AVALANCHE_KEY_ENCODING: "{{ subnet_txs_key_encoding }}"
   when:
     - not node_is_validator
-    - not node_is_pending_validator
     - subnet_id != avalanche_primary_network_id

--- a/scripts/update_vm_versions.py
+++ b/scripts/update_vm_versions.py
@@ -20,7 +20,7 @@ VARS_YAML_HEADER_SIZE = 3
 VMS_REPOS = {
     "subnet-evm": "ava-labs/subnet-evm",
 }
-MIN_AVAX_VERSION = "1.10.0"
+MIN_AVAX_VERSION = "1.11.3"
 
 vms_versions_comp = {}
 


### PR DESCRIPTION
### Changes

- upgrade ash_cli version to 0.4.3
- upgrade AvalancheGo verison to 1.11.3
- delete `Check if node is a pending validator` task as the 0.4.3 version of ash_cli does not process it
