### PR TITLE
Upgrade and patch

### DIFF
--- a/playbooks/create_subnet.yml
+++ b/playbooks/create_subnet.yml
@@ -19,6 +19,7 @@
       tags:
         - validate
         - add-validators
+      when: hostvars[groups['subnet_txs_host'][0]].subnet_validators_add
 
 - name: Subnet creation recap
   hosts: subnet_txs_host[0]

--- a/roles/evm/blockscout/files/services/backend.yml
+++ b/roles/evm/blockscout/files/services/backend.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   backend:
-    image: blockscout/blockscout:6.10.1
+    image: ghcr.io/blockscout/blockscout:8.1.1
     pull_policy: always
     restart: always
     stop_grace_period: 5m

--- a/roles/evm/blockscout/files/services/frontend.yml
+++ b/roles/evm/blockscout/files/services/frontend.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   bc_frontend:
-    image: ghcr.io/blockscout/frontend:v1.37.4
+    image: ghcr.io/blockscout/frontend:v2.0.3
     pull_policy: always
     platform: linux/amd64
     restart: always

--- a/roles/evm/blockscout/files/services/smart-contract-verifier.yml
+++ b/roles/evm/blockscout/files/services/smart-contract-verifier.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   smart-contract-verifier:
-    image: ghcr.io/blockscout/smart-contract-verifier:v1.9.2
+    image: ghcr.io/blockscout/smart-contract-verifier:v1.10.0
     pull_policy: always
     platform: linux/amd64
     restart: always

--- a/roles/evm/blockscout/files/services/stats.yml
+++ b/roles/evm/blockscout/files/services/stats.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   stats:
-    image: ghcr.io/blockscout/stats:v2.3.0
+    image: ghcr.io/blockscout/stats:v2.9.0
     build: .
     pull_policy: always
     platform: linux/amd64

--- a/roles/evm/blockscout/templates/default.conf.template.j2
+++ b/roles/evm/blockscout/templates/default.conf.template.j2
@@ -97,5 +97,10 @@ server {
         proxy_set_header      Upgrade "$http_upgrade";
         proxy_set_header      Connection $connection_upgrade;
         proxy_cache_bypass    $http_upgrade;
+        # Needed to fix "upstream sent too big header while reading response header from upstream" after enabling WalletConnect
+        proxy_buffer_size          128k;
+        proxy_buffers              4 256k;
+        proxy_busy_buffers_size    256k;
+        proxy_temp_file_write_size 256k;
     }
 }

--- a/roles/node/defaults/main.yml
+++ b/roles/node/defaults/main.yml
@@ -63,6 +63,7 @@ avalanchego_network_id: fuji
 ## Node IDs of the bootstrap nodes on networks other than `mainnet`, `testnet` and `fuji`
 avalanchego_bootstrap_node_ids:
   - NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg
+## URL or path to the bootstrap database
 avalanchego_bootstrap_db: ""
 
 # Subnets

--- a/roles/node/tasks/bootstrap-db.yml
+++ b/roles/node/tasks/bootstrap-db.yml
@@ -1,9 +1,20 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2022-2024, E36 Knots
----
+--- 
+- name: Check if bootstrap_db is an url
+  set_fact:
+    avalanchego_bootstrap_db_url: "{{ avalanchego_bootstrap_db }}"
+  when: (avalanchego_bootstrap_db is defined) and (avalanchego_bootstrap_db|length > 0) and (avalanchego_bootstrap_db is url)
+
+- name: Set bootstrap database dir name
+  set_fact:
+    avalanchego_bootstrap_db: "{{ avalanchego_db_dir }}/{{ avalanchego_bootstrap_db | urlsplit('path') | basename }}"
+  when: avalanchego_bootstrap_db_url is defined
+
 - name: Unpack bootstrap database
   unarchive:
-    src: "{{ avalanchego_bootstrap_db }}"
+    remote_src: "{{ (avalanchego_bootstrap_db_url is defined) | bool }}"
+    src: "{{ avalanchego_bootstrap_db if (avalanchego_bootstrap_db_url is not defined) else avalanchego_bootstrap_db_url }}"
     dest: "{{ avalanchego_db_dir }}"
     owner: "{{ avalanchego_user }}"
     group: "{{ avalanchego_group }}"

--- a/roles/node/tasks/bootstrap-db.yml
+++ b/roles/node/tasks/bootstrap-db.yml
@@ -6,11 +6,6 @@
     avalanchego_bootstrap_db_url: "{{ avalanchego_bootstrap_db }}"
   when: (avalanchego_bootstrap_db is defined) and (avalanchego_bootstrap_db|length > 0) and (avalanchego_bootstrap_db is url)
 
-- name: Set bootstrap database dir name
-  set_fact:
-    avalanchego_bootstrap_db: "{{ avalanchego_db_dir }}/{{ avalanchego_bootstrap_db | urlsplit('path') | basename }}"
-  when: avalanchego_bootstrap_db_url is defined
-
 - name: Unpack bootstrap database
   unarchive:
     remote_src: "{{ (avalanchego_bootstrap_db_url is defined) | bool }}"


### PR DESCRIPTION
### Linked issues

- Fixes #137 

### Changes

- Don't add inventory validator if subnet_validators_add is false (was the case [in the subnet role](https://github.com/AshAvalanche/ansible-avalanche-collection/blob/55cd1484e3d3917e4d2a82aff532f4a5fe6545c8/roles/subnet/tasks/main.yml#L31))
- The `avalanchego_bootstrap_db` environment variable now supports URLs.
- Upgrade all Blockscout services:
  Concretely, for the end user:
  
  * **New API entry points**
  
    * You can now fetch internal and external transactions via dedicated endpoints (`/api/v2/internal-transactions`, `/api/v2/transactions/:hash/external-transactions`) without workarounds.
    * Account Abstraction (AA) status is available at `/api/v2/proxy/account-abstraction/status`.
  
  * **Better block and metrics visibility**
  
    * See `internal_transactions_count` on a block’s detail page.
    * `/metrics` endpoint exposed to monitor the indexer in real time.
  
  * **Support for new chains**
  
    * NeonVM and Solana are now indexed.
    * Improved backfill and reading for Arbitrum, Filecoin, Celo, etc.
  
  * **Enhanced NFT features**
  
    * Manual NFT re‐fetch via the Admin API.
    * Arweave metadata parsing and richer search tagging.
  
  * **Security & anti‐bot**
  
    * CAPTCHA on wallet login (Indexer), with a `RE_CAPTCHA_BYPASS_TOKEN` for dev bypass.
  
  * **Performance & reliability**
  
    * Grouped ABI aggregation and batched requests to speed up log indexing.
    * Finer health monitoring (`HEALTH_MONITOR_*`) to detect and self-heal stalls.
  
  * **Breaking changes**
  
    * Some endpoints moved (e.g. `/api/v1/health*` → `/api/health/**`, deprecated `smart-contracts/.../methods-*`): update your clients.
    * Several environment variables renamed—adjust your configs accordingly.
  
  **In short:** richer, faster data access; broader chain & NFT support; improved stability—just be sure to update any affected URLs and env-vars in your integrations.
